### PR TITLE
Merge:  METS-Export of newspapers fails (#193)

### DIFF
--- a/ugh/src/ugh/dl/DocStruct.java
+++ b/ugh/src/ugh/dl/DocStruct.java
@@ -539,6 +539,7 @@ public class DocStruct implements Serializable {
 
         // Copy the link to the parent.
         newStruct.setParent(this.getParent());
+        newStruct.origObject = this.origObject;
         if (this.logical) {
             newStruct.logical = this.logical;
         }


### PR DESCRIPTION
Bug fix for bug: https://github.com/goobi/goobi-production/issues/193

**Prerequisite:** Development of this bug-fix was based on the solution for #5 _The whole logical structure is written to the anchors_
