### PR TITLE
Clean line endings and spelling

### DIFF
--- a/ugh/src/converter/Conversion/StarterMetaDataConversion.java
+++ b/ugh/src/converter/Conversion/StarterMetaDataConversion.java
@@ -232,7 +232,7 @@ public class StarterMetaDataConversion {
 
 							myCommitLog.info(procFile.getAbsolutePath()	+ " stringValidator turned off - " + conversionFailure.toString());
 
-							// Tokenizer Validation, using newFile wich is the backup of the original file
+							// Tokenizer Validation, using newFile which is the backup of the original file
 							if (myValidators.getTokenizerValidation(newFile, fileA)) {
 
 								myLogger.info("File " + procFile.getAbsolutePath()

--- a/ugh/src/converter/logger/Commit.java
+++ b/ugh/src/converter/logger/Commit.java
@@ -1,7 +1,7 @@
 package converter.logger;
 
 /**
- * This class is only used to seperate loggers
+ * This class is only used to separate loggers
  * @author Wulf
  *
  */

--- a/ugh/src/converter/logger/Filesave.java
+++ b/ugh/src/converter/logger/Filesave.java
@@ -1,7 +1,7 @@
 package converter.logger;
 
 /**
- * This class is only used to seperate loggers
+ * This class is only used to separate loggers
  * @author Wulf
  *
  */

--- a/ugh/src/converter/logger/Rollback.java
+++ b/ugh/src/converter/logger/Rollback.java
@@ -1,7 +1,7 @@
 package converter.logger;
 
 /**
- * This class is only used to seperate loggers
+ * This class is only used to separate loggers
  * @author Wulf
  *
  */

--- a/ugh/src/converter/logger/UGH.java
+++ b/ugh/src/converter/logger/UGH.java
@@ -1,7 +1,7 @@
 package converter.logger;
 
 /**
- * This class is only used to seperate loggers
+ * This class is only used to separate loggers
  * @author Wulf
  *
  */

--- a/ugh/src/converter/processing/MetaFixer.java
+++ b/ugh/src/converter/processing/MetaFixer.java
@@ -144,17 +144,17 @@ public class MetaFixer implements Validatable {
 	}
 
 	public void setBaseFolder(String path) {
-		// implementation not neccesary in this class
+		// implementation not necessary in this class
 
 	}
 
 	public void setID(String id) {
-		// implementation not neccesary in this class
+		// implementation not necessary in this class
 
 	}
 
 	public void setSearchString(String searchExpression) {
-		// implementation not neccesary in this class
+		// implementation not necessary in this class
 
 	}
 

--- a/ugh/src/converter/processing/ProcessStarter.java
+++ b/ugh/src/converter/processing/ProcessStarter.java
@@ -45,7 +45,7 @@ public class ProcessStarter {
 		List<String> myIds = UsedRuleSetParser.getIds(usedRulesSetPath);
 
 		myLogger
-				.info("The following ids match the search pattern and will be examined for the occurence of replacement conditions:"
+				.info("The following ids match the search pattern and will be examined for the occurrence of replacement conditions:"
 						+ myIds);
 
 		try {
@@ -62,7 +62,7 @@ public class ProcessStarter {
 		// if caught here filepath validator had failed
 		catch (Exception e) {
 			myLogger
-					.fatal("The program was terminated with an exception before examining any metadata because an inconsistency was detected in the filesystem. Folders supposed to be existant according to usedRules.xml or contained files within (meta.xml) are missing."
+					.fatal("The program was terminated with an exception before examining any metadata because an inconsistency was detected in the filesystem. Folders supposed to be existent according to usedRules.xml or contained files within (meta.xml) are missing."
 							+ e.getStackTrace());
 			throw e;
 		}
@@ -116,7 +116,7 @@ public class ProcessStarter {
 		}
 
 		myLogger
-				.info("Program terminated normally. The presented data was examined and replaced in case of occurences of the conditions required");
+				.info("Program terminated normally. The presented data was examined and replaced in case of occurrences of the conditions required");
 
 		/*
 		 * - regex - vorhandensein der ordner - vorhandensein der meta.xml -

--- a/ugh/src/converter/ruleSetProcessing/SlubReader.java
+++ b/ugh/src/converter/ruleSetProcessing/SlubReader.java
@@ -35,7 +35,7 @@ public class SlubReader extends RulesetReader {
 		Element manuscriptRoot = (Element) mr.getDocument().getRootElement()
 				.clone();
 
-		//now create a SlubElement from the slub.xml root Element to start the compare proceedure
+		//now create a SlubElement from the slub.xml root Element to start the compare procedure
 		mySlubRoot = new SlubElement(super.getDocument().getRootElement());
 
 		// add those element names which you would like to keep as a unit if they differ

--- a/ugh/src/gov/loc/mets/Helper.java
+++ b/ugh/src/gov/loc/mets/Helper.java
@@ -1,1 +1,1196 @@
-package gov.loc.mets;/******************************************************************************* * gov.loc.mets / Helper.java *  * Copyright 2010 Center for Retrospective Digitization, Göttingen (GDZ) *  * http://gdz.sub.uni-goettingen.de *  * This program is free software; you can redistribute it and/or modify it * under the terms of the GNU Lesser General Public License as published by * the Free Software Foundation; either version 3 of the License, or (at your * option) any later version. *  * This Library is distributed in the hope that it will be useful, but WITHOUT * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License * for more details. *  * You should have received a copy of the GNU Lesser General Public License * along with this library; if not, write to the Free Software Foundation, * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA. ******************************************************************************/import gov.loc.mets.DivType.Fptr;import gov.loc.mets.FileType.FLocat;import gov.loc.mets.MdSecType.MdWrap;import gov.loc.mets.MdSecType.MdWrap.XmlData;import gov.loc.mets.MetsType.FileSec;import gov.loc.mets.MetsType.StructLink;import gov.loc.mets.MetsType.FileSec.FileGrp;import gov.loc.mets.StructLinkType.SmLink;import java.io.DataInputStream;import java.io.IOException;import java.net.URL;import java.net.URLConnection;import java.util.Iterator;import java.util.LinkedList;import java.util.List;import java.util.UUID;import org.apache.xmlbeans.XmlAnyURI;import org.apache.xmlbeans.XmlException;import org.apache.xmlbeans.XmlObject;import org.w3c.dom.Document;import org.w3c.dom.Node;/******************************************************************************* * <p> * Helper class to parse and create METS files more easily. * </p> *  * @author Markus Enders * @version 2009-10-21 * @since Jan 2007 *  *        TODOLOG *  *        TODO This should be a seperate maven project! *  *        TODO Update the HelperTest class and use it for JUnit tests! *  *        CHANGELOG *  *        21.10.2009 --- Funk --- Refactored some conditionals. *  *        20.10.2009 --- Funk --- Added method for retrieving DivTypes by *        DivType ID --- Corrected some typos. *  ******************************************************************************/public class Helper {	/***************************************************************************	 * STATIC FINALS	 **************************************************************************/	private final static String	version		= "0.2-20091021";	// Define.	private final static int	DIGIPROVMD	= 1;	private final static int	RIGHTSMD	= 2;	private final static int	TECHMD		= 3;	private final static int	SOURCEMD	= 4;	/***************************************************************************	 * INSTANCE VARIABLES	 **************************************************************************/	// The Mets wrapper element <mets>.	private MetsType			mets;	/***************************************************************************	 * CONSTRUCTORS	 **************************************************************************/	/***************************************************************************	 * <p>	 * Default Constructor.	 * </p>	 * 	 * @param inMets	 **************************************************************************/	public Helper(MetsType inMets) {		this.mets = inMets;	}	/***************************************************************************	 * WHAT THE OBJECT DOES	 **************************************************************************/	/***************************************************************************	 * @param inDiv	 * @param inContent	 * @return	 **************************************************************************/	public MdSecType addDmdSecType(DivType inDiv, String inContent) {		LinkedList<String> l1 = null;		MdSecType newDmdSecType = createDescriptiveMetadata(inContent);		// Happens, when inContent is XML compliant.		if (newDmdSecType == null) {			return null;		}		// Get ID of newDmdSecType.		String newID = newDmdSecType.getID();		// Add this id to the inDiv.		List<String> l = inDiv.getDMDID();		if (l == null) {			l1 = new LinkedList<String>();		} else {			l1 = new LinkedList<String>(l);		}		l1.add(newID);		inDiv.setDMDID(l1);		return newDmdSecType;	}	/***************************************************************************	 * <p>	 * Creates a new DmdSec object for a given DivType. Cause the content is	 * transmitted as a byte-array, it will be regarded as binary content.	 * Therefore an &lt;binData&gt; element will be created.<br/>	 * 	 * The method will construct an internal unique identifier for the DmdSec	 * automatically and will add this identifier to the &lt;div&gt;.	 * </p>	 * 	 * @param inDiv	 *            the &lt;div&gt; element, which will conntect	 * @param inContent	 *            a byte-array containing the binary content.	 * @return	 **************************************************************************/	public MdSecType addDmdSecType(DivType inDiv, byte[] inContent) {		LinkedList<String> l1 = null;		MdSecType newDmdSecType = createDescriptiveMetadata(inContent);		// Get ID of newDmdSecType.		String newID = newDmdSecType.getID();		// Add this id to the inDiv.		List<String> l = inDiv.getDMDID();		if (l == null) {			l1 = new LinkedList<String>();		} else {			l1 = new LinkedList<String>(l);		}		l1.add(newID);		inDiv.setDMDID(l1);		return newDmdSecType;	}	/***************************************************************************	 * <p>	 * Creates a new DMDSec with xml compliant content. Identifier for the	 * DMDSec is created automatically.	 * </p>	 * 	 * @param mets	 * @param content	 *            content must be xml compliant	 * @return	 **************************************************************************/	private MdSecType createDescriptiveMetadata(String content) {		String dmdid_string = createNewXMLID("dmdsec");		// Create descriptive metadata section.		MdSecType dmdSec = this.mets.addNewDmdSec();		dmdSec.setID(dmdid_string);		// Check, if inContent is XML compliant or not create an xmlData		// section, if it is xml compliant, otherwise a binData section.		// Create a new <MdWrap> element.		MdSecType.MdWrap mdwrap = dmdSec.addNewMdWrap();		// Create new <xmlData> element. We have to create DOM node, to avoid		// having a schema for the xml content; for xmlbeans a schema and the		// derived classes are a must.		MdSecType.MdWrap.XmlData xml = mdwrap.addNewXmlData();		Node xmlnode = xml.getDomNode();		Document domdocument = xmlnode.getOwnerDocument();		Node contentnode = domdocument.createTextNode(content);		xmlnode.appendChild(contentnode);		// XmlObject xo = null;		// try {		// xo = XmlObject.Factory.parse(content);		// } catch (XmlException e) {		// e.printStackTrace();		// return null;		// }		// // XmlString implements the XmlObject interface; therefore it can be		// // added to the <XmlData> element XmlData object.		// xml.set(xo);		return dmdSec;	}	/***************************************************************************	 * @param inDocument	 *            another xml-document, e.g. ModsDocument etc.	 * @return	 **************************************************************************/	private MdSecType createDescriptiveMetadata(XmlObject inDocument) {		// Create identifier.		String dmdid_string = createNewXMLID("dmdsec");		// Create descriptive metadata section.		MdSecType dmdSec = this.mets.addNewDmdSec();		dmdSec.setID(dmdid_string);		// Ccheck, if inContent is XML compliant or not create an xmlData		// section, if it is xml compliant otherwise a binData section.		// Create a new <MdWrap> element.		MdSecType.MdWrap mdwrap = dmdSec.addNewMdWrap();		// Ccreate new <xmlData> element.		MdSecType.MdWrap.XmlData xml = mdwrap.addNewXmlData();		// Any Document implements the XmlObject interface; therefore it can be		// added to the <XmlData> element / XmlData object.		xml.set(inDocument);		return dmdSec;	}	/***************************************************************************	 * <p>	 * Creates a new DMDSec with binary content.	 * </p>	 * 	 * @param mets	 * @param content	 * @return	 **************************************************************************/	private MdSecType createDescriptiveMetadata(byte[] content) {		String dmdid_string = createNewXMLID("dmdsec");		// Create descriptive metadata section.		MdSecType dmdSec = this.mets.addNewDmdSec();		dmdSec.setID(dmdid_string);		// Check, if inContent is XML compliant or not create an xmlData		// section, if it is xml compliant otherwise a binData section.		// Create a new <MdWrap> element.		MdSecType.MdWrap mdwrap = dmdSec.addNewMdWrap();		mdwrap.setBinData(content);		return dmdSec;	}	/***************************************************************************	 * @param content	 * @param mdTypeValue	 * @param mdPart	 * @return	 **************************************************************************/	public MdSecType addAmdSecType(XmlObject content, String mdTypeValue,			int mdPart) {		MdSecType result = null;		AmdSecType amdsec = this.mets.addNewAmdSec();		// Create identifier for amdsec.		String amdid = createNewXMLID("amdsec");		amdsec.setID(amdid);		// Create subsection and create id for the subsection.		String id = null;		if (mdPart == DIGIPROVMD) {			result = amdsec.addNewDigiprovMD();			id = createNewXMLID("digiprov");		} else if (mdPart == RIGHTSMD) {			result = amdsec.addNewRightsMD();			id = createNewXMLID("rights");		} else if (mdPart == TECHMD) {			result = amdsec.addNewTechMD();			id = createNewXMLID("tech");		} else if (mdPart == SOURCEMD) {			result = amdsec.addNewSourceMD();			id = createNewXMLID("source");		} else {			// Unknown type, should really throw an exception here.			return null;		}		// Create identifier for result.		result.setID(id);		MdWrap mdwrap = createMDWrap(result, mdTypeValue);		// Add content.		XmlData xmldata = mdwrap.addNewXmlData();		xmldata.set(content);		return result;	}	/***************************************************************************	 * @param content	 * @param mdTypeValue	 * @param mdPart	 * @return	 * @throws XmlException	 **************************************************************************/	public MdSecType addAmdSecType(String content, String mdTypeValue,			int mdPart) {		MdSecType result = null;		AmdSecType amdsec = this.mets.addNewAmdSec();		// Create identifier for amdsec.		String amdid = createNewXMLID("amdsec");		amdsec.setID(amdid);		// Create subsection and create id for the subsection.		String id = null;		if (mdPart == DIGIPROVMD) {			result = amdsec.addNewDigiprovMD();			id = createNewXMLID("digiprov");		} else if (mdPart == RIGHTSMD) {			result = amdsec.addNewRightsMD();			id = createNewXMLID("rights");		} else if (mdPart == TECHMD) {			result = amdsec.addNewTechMD();			id = createNewXMLID("tech");		} else if (mdPart == SOURCEMD) {			result = amdsec.addNewSourceMD();			id = createNewXMLID("source");		} else {			// Unknown type, should really throw an exception here.			return null;		}		// Create identifier for result.		result.setID(id);		MdWrap mdwrap = createMDWrap(result, mdTypeValue);		// Add content.		XmlData xmldata = mdwrap.addNewXmlData();		// We have to create DOM node, to avoid having a schema for the xml		// content; for xmlbeans a schema and the derived classes are a must.		// Get DOM node.		Node xmlnode = xmldata.getDomNode();		Document domdocument = xmlnode.getOwnerDocument();		Node contentnode = domdocument.createTextNode(content);		xmlnode.appendChild(contentnode);		return result;	}	/***************************************************************************	 * @param content	 * @param mdTypeValue	 * @param mdPart	 * @return	 **************************************************************************/	public MdSecType addAmdSecType(byte[] content, String mdTypeValue,			int mdPart) {		MdSecType result = null;		AmdSecType amdsec = this.mets.addNewAmdSec();		// Ccreate identifier for amdsec.		String amdid = createNewXMLID("amdsec");		amdsec.setID(amdid);		// Create subsection and create id for the subsection.		String id = null;		if (mdPart == DIGIPROVMD) {			result = amdsec.addNewDigiprovMD();			id = createNewXMLID("digiprov");		} else if (mdPart == RIGHTSMD) {			result = amdsec.addNewRightsMD();			id = createNewXMLID("rights");		} else if (mdPart == TECHMD) {			result = amdsec.addNewTechMD();			id = createNewXMLID("tech");		} else if (mdPart == SOURCEMD) {			result = amdsec.addNewSourceMD();			id = createNewXMLID("source");		} else {			// Unknown type, should really throw an exception here.			return null;		}		// Create identifier for result.		result.setID(id);		MdWrap mdwrap = createMDWrap(result, mdTypeValue);		// Add content.		mdwrap.setBinData(content);		return result;	}	/***************************************************************************	 * <p>	 * Retrieves the appropriate descriptive metadata section of a given type.	 * The type is stored in the TYPE-attribute. The comparison is case	 * sensitive.	 * </p>	 * 	 * @param metsDoc	 *            the MetsDocument object	 * @param inDiv	 *            the DivType object	 * @param type	 *            the type as a string; type is case sensitive.	 * @return the MdSecType object, which matches . If several objects with the	 *         same type are available, the first one is returned.	 **************************************************************************/	public MdSecType getMetadataSectionByType(DivType inDiv, String type) {		// Get all IDs for administrative metadata sections.		List<String> allmdids = inDiv.getADMID();		if (allmdids == null) {			return null;		}		Iterator<String> it = allmdids.iterator();		while (it.hasNext()) {			String admid = it.next();			// Get section by ID verify the type of metadata.			MdSecType dmdSec = getDmdSecByID(admid);			// Get <mdWrap> element.			MdSecType.MdWrap mdwrap = dmdSec.getMdWrap();			if (mdwrap != null) {				MdSecType.MdWrap.MDTYPE.Enum e = mdwrap.getMDTYPE();				// Compare value of MDTYPE here.				if (e.equals(MdSecType.MdWrap.MDTYPE.OTHER)) {					String othermdtype = mdwrap.getOTHERMDTYPE();					// If it's PREMIS metadata.					if (othermdtype.equals(type)) {						// We found the LMER metadata type; create a PREMIS						// metadata for it.						return dmdSec;					}				}			}		}		return null;	}	/***************************************************************************	 * <p>	 * Retrieves a &lt;amdSec&gt; with a given ID; this ID is used to link from	 * the appropriate <div> element to the attached metadata.	 * </p>	 * 	 * @param id	 *            xml-id	 * @return	 **************************************************************************/	public AmdSecType getAmdSecByID(String id) {		Object o = getAmdSecByID(id, false);		if (o != null) {			AmdSecType result = (AmdSecType) o;			return result;		}		return null;	}	/***************************************************************************	 * <p>	 * Gets the descriptive metadata section defined by the ID.	 * </p>	 * 	 * @param inDoc	 *            the MetsDocument which should contain the DmdSec element	 * @param id	 *            unique ID of the descriptive metadata section	 * @return	 **************************************************************************/	public MdSecType getDmdSecByID(String id) {		// Get all descriptive Metadata sections as an array.		List<MdSecType> mdsections = this.mets.getDmdSecList();		// Iterate over all sections.		for (int i = 0; i < mdsections.size(); i++) {			MdSecType mdsec = mdsections.get(i);			String sectionid = mdsec.getID();			if (sectionid.equals(id)) { // compare the id and the given id				return mdsec;			}		}		return null;	}	/***************************************************************************	 * <p>	 * Retrieves the content of a descriptive/administrative metadata section;	 * if the metadata is referenced by a <mdRef> element, the data is loaded	 * via http (other protocols are currently unsupported.	 * </p>	 * 	 * @param the	 *            appropriate MdSecType element to the <dmdSec>	 * @return the content of the section as a string	 * @throws IOException	 **************************************************************************/	public String getMdSecContents(MdSecType mdsec) throws IOException {		String result = null;		// Get mdWrap and mdRef elements.		MdSecType.MdRef mdref = mdsec.getMdRef();		MdSecType.MdWrap mdwrap = mdsec.getMdWrap();		if (mdref != null) {			// Get the http URL/URI.			XmlAnyURI uri = mdref.xgetHref();			// Convert the URI to String.			String uri_String = uri.toString();			// Make an HTTP request, the result of this request is returned as a			// string.			result = makeHTTPRequest(uri_String);		}		if (mdwrap != null) {			// Get xml-data and convert it to String.			MdSecType.MdWrap.XmlData xmldata = mdwrap.getXmlData();			result = xmldata.toString();		}		return result;	}	/***************************************************************************	 * <p>	 * Retrieves all	 * 	 * <pre>	 * StructMapType	 * </pre>	 * 	 * objects of a given type.	 * </p>	 * 	 * @param type	 * @return List containing StructMapType objects, if none was found null is	 *         returned.	 **************************************************************************/	public List<StructMapType> getStructMapByType(String type) {		List<StructMapType> resultList = new LinkedList<StructMapType>();		List<StructMapType> structmap = this.mets.getStructMapList();		for (int i = 0; i < structmap.size(); i++) {			if ((structmap.get(i).getTYPE() != null)					&& (structmap.get(i).getTYPE().equals(type))) {				resultList.add(structmap.get(i));			}		}		if (resultList.size() == 0) {			return null;		}		return resultList;	}	/***************************************************************************	 * <p>	 * Retrieves all	 * 	 * <pre>	 * StructMapType	 * </pre>	 * 	 * objects with a given label.	 * </p>	 * 	 * @param type	 * @return List containing StructMapType objects, if none was found null is	 *         returned	 **************************************************************************/	public List<StructMapType> getStructMapByLabel(String label) {		List<StructMapType> resultList = new LinkedList<StructMapType>();		List<StructMapType> structmap = this.mets.getStructMapList();		for (int i = 0; i < structmap.size(); i++) {			if ((structmap.get(i).getLABEL() != null)					&& (structmap.get(i).getLABEL().equals(label))) {				resultList.add(structmap.get(i));			}		}		if (resultList.size() == 0) {			return null;		}		return resultList;	}	/***************************************************************************	 * <p>	 * Retrieves all	 * 	 * <pre>	 * StructMapType	 * </pre>	 * 	 * objects with a given ID.	 * </p>	 * 	 * @param type	 * @return the StructMapType or null	 **************************************************************************/	public StructMapType getStructMapByID(String id) {		List<StructMapType> structmap = this.mets.getStructMapList();		for (int i = 0; i < structmap.size(); i++) {			if ((structmap.get(i).getID() != null)					&& (structmap.get(i).getID().equals(id))) {				return structmap.get(i);			}		}		return null;	}	/***************************************************************************	 * <p>	 * Retrieves a FileType object with the given ID.	 * </p>	 * 	 * @param id	 * @return FileType object or null (if none available)	 **************************************************************************/	public FileType getFileByID(String id) {		FileSec filesec = this.mets.getFileSec();		List<FileGrp> filegroup = filesec.getFileGrpList();		// Iterate over all filegroups.		for (int i = 0; i < filegroup.size(); i++) {			FileType file = getFileByID(id, filegroup.get(i));			if (file != null) {				return file;			}		}		return null;	}	/***************************************************************************	 * <p>	 * Retrieves all &lt;div&gt; elements, which are linked to a given	 * &lt;div&gt; element in the structLink-section, no matter if the	 * relationship points to or from the given &lt;div&gt; element.	 * </p>	 * 	 * @param inDiv	 * @return	 **************************************************************************/	public List<SmLink> getAllLinkedDivs(DivType inDiv) {		return getAllLinkedDivs(inDiv, true, true);	}	/***************************************************************************	 * <p>	 * Retrieves all &lt;div&gt; elements, which point to the given &lt;div&gt;	 * element in the structLink section.	 * </p>	 * 	 * @param inDiv	 * @return	 **************************************************************************/	public List<SmLink> getAllLinkedFromDivs(DivType inDiv) {		return getAllLinkedDivs(inDiv, false, true);	}	/***************************************************************************	 * <p>	 * Retrieves all &lt;div&gt; elements, which point from the given	 * &lt;div&gt; element in the structLink section.	 * </p>	 * 	 * @param inDiv	 * @return	 **************************************************************************/	public List<SmLink> getAllLinkedToDivs(DivType inDiv) {		return getAllLinkedDivs(inDiv, true, false);	}	/**************************************************************************	 * <p>	 * Gets a StructMap div type by the given div ID.	 * </p>	 * 	 * @param theId	 * @param theDiv	 * @return The appropriate StructMap if existing, NULL otherwise.	 **************************************************************************/	public DivType getStructMapDiv(String theId) {		// Go through all StructMaps.		for (StructMapType smt : this.mets.getStructMapList()) {			// Call the private method recursively for every first StructMap div			// (only one is allowed here!).			return getStructMapDiv(theId, smt.getDiv());		}		return null;	}	/***************************************************************************	 * <p>	 * Creates a <file> object as the last object in a given <FileGrp>. The	 * <file> object will have a new, unique ID attribute and a single <FLocat>	 * sub element. The LOCTYPE attribute is filled automatically, depending on	 * the value of the file's location.	 * </p>	 * 	 * @param inDiv	 * @param filegroup	 * @param url	 * @return FileType object, which represents the new <file> element.	 **************************************************************************/	public FileType createFileType(DivType inDiv, FileGrp filegroup, String url) {		// Ccreate new FileType.		FileType ft = filegroup.addNewFile();		// Add <mets:FLocat> element.		FLocat filelocation = ft.addNewFLocat();		if (url.startsWith("http")) {			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.URL);		} else if (url.startsWith("doi")) {			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.DOI);		} else if (url.startsWith("handle")) {			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.HANDLE);		} else if (url.startsWith("urn")) {			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.URN);		} else {			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.OTHER);		}		// Set URL; create identifier for file and add one.		filelocation.setHref(url);		String fileidentifier = "";		// Set file pointer for the new <file> element.		ft.setID(fileidentifier);		Fptr filepointer = inDiv.addNewFptr();		// Set fileidentifier.		filepointer.setFILEID(fileidentifier);		return ft;	}	/***************************************************************************	 * PRIVATE (AND PROTECTED) METHODS	 **************************************************************************/	/***************************************************************************	 * <p>	 * Private class, which is used by	 * 	 * <pre>	 * getAMDSecByID	 * </pre>	 * 	 * method. From an array of MdSecType objects it finds the one with the	 * given ID.<br/>	 * 	 * Usually.	 * </p>	 * 	 * @param inMDsec	 * @param inID	 * @return an MdSecType object	 **************************************************************************/	private MdSecType getMdSecTypeByID(List<MdSecType> inMDsec, String inID) {		for (int i = 0; i < inMDsec.size(); i++) {			MdSecType current = inMDsec.get(i);			String id = current.getID();			if ((id != null) && (id.equals(inID))) {				return current;			}		}		return null;	}	/***************************************************************************	 * @param type	 * @return	 **************************************************************************/	private String createNewXMLID(String type) {		String xmlid = null;		UUID uuid = UUID.randomUUID();		String uuidstring = uuid.toString();		if (type.equals("amdsec")) {			xmlid = "amd" + uuidstring;		} else if (type.equals("dmdsec")) {			xmlid = "dmd" + uuidstring;		} else if (type.equals("tech")) {			xmlid = "tech" + uuidstring;		} else if (type.equals("digiprov")) {			xmlid = "dipr" + uuidstring;		} else if (type.equals("rights")) {			xmlid = "rgt" + uuidstring;		} else if (type.equals("source")) {			xmlid = "src" + uuidstring;		} else if (type.equals("file")) {			xmlid = "fl" + uuidstring;		}		return xmlid;	}	/**************************************************************************	 * <p>	 * Gets a StructMap div type by the given ID and a given div.	 * </p>	 * 	 * @param theId	 * @param theDiv	 * @return The appropriate StructMap if existing, NULL otherwise.	 **************************************************************************/	private DivType getStructMapDiv(String theId, DivType theDiv) {		// Firt check the given div type.		if (theDiv.getID().equals(theId)) {			return theDiv;		}		// Then check all divs from the the div list, if existing.		for (DivType dt : theDiv.getDivList()) {			DivType result = getStructMapDiv(theId, dt);			if (result != null) {				return result;			}		}		return null;	}	/***************************************************************************	 * <p>	 * Makes a simple HTTP call to a URI; this method is used for internal	 * purposes only. The content of the request is returned as a string.	 * </p>	 * 	 * @param uri	 * @return	 * @throws IOException	 **************************************************************************/	private String makeHTTPRequest(String uri) throws IOException {		URL url;		URLConnection urlConn = null;		String str;		url = new URL(uri);		urlConn = url.openConnection();		// Get response data.		DataInputStream input = new DataInputStream(urlConn.getInputStream());		while (null != ((str = input.readLine()))) {			// Do nothing!		}		return str;	}	/***************************************************************************	 * <p>	 * Retrieves all &lt;div&gt; elements which are linked to a given	 * &lt;div&gt; (inDiv) using the &lt;structLink&gt; section. Depending on	 * the checkto and checkfrom switches, the linked &lt;div&gt; elements are	 * only searched in the "to" or in the "from" attribute of the	 * &lt;smLink&gt; element.	 * </p>	 * 	 * @param inDiv	 *            the &lt;div&gt; element for which all linked &lt;div&gt;	 *            elements should be found.	 * @param checkto	 * @param checkfrom	 * @return	 **************************************************************************/	private List<SmLink> getAllLinkedDivs(DivType inDiv, boolean checkto,			boolean checkfrom) {		LinkedList<SmLink> result = new LinkedList<SmLink>();		// Get ID for inDiv, this ID is used as a target.		String divid = inDiv.getID();		if (divid == null) {			// Has no ID attribute; can't neither source nor target of an smlink			// element.			return null;		}		// Get structLink section.		StructLink structlink = this.mets.getStructLink();		List<SmLink> links = structlink.getSmLinkList();		for (int i = 0; i < links.size(); i++) {			boolean from = false;			boolean to = false;			if (checkfrom && links.get(i).getFrom() != null					&& links.get(i).getFrom().equals(divid)) {				from = true;			} else if (checkfrom && (links.get(i).getFrom() == null)					|| !links.get(i).getFrom().equals(divid)) {				// Checkfrom should be checked, but was not equal.				from = false;			} else {				// Checkfrom ist false, from field is not beeing tested.				from = true;			}			if (checkto && links.get(i).getTo() != null					&& links.get(i).getTo().equals(divid)) {				to = true;			} else if (checkto && (links.get(i).getTo() == null)					|| !links.get(i).getTo().equals(divid)) {				// Checkfrom should be checked, but was not equal.				to = false;			} else {				// checkto ist false, to field is not beeing tested.				to = true;			}			if (from && to) {				// In either the from or the two link.				result.add(links.get(i));			}		}		// No hits, return null.		if (result.size() == 0) {			return null;		}		return result;	}	/***************************************************************************	 * <p>	 * Retrieves a file by ID from a filegroup, including all sub filegroups.	 * </p>	 * 	 * @param id	 * @param filegroup	 * @return a FileType or null	 **************************************************************************/	private FileType getFileByID(String id, FileGrpType filegroup) {		// Iterate over all files.		List<FileType> file = filegroup.getFileList();		for (int i = 0; i < file.size(); i++) {			if ((file.get(i).getID() != null)					&& (file.get(i).getID().equals(id))) {				// Found the type.				return file.get(i);			}		}		// Nothing found, so get the list of all sub groups and iterate over		// those subgroups.		List<FileGrpType> subfilegroup = filegroup.getFileGrpList();		for (int x = 0; x < subfilegroup.size(); x++) {			FileType singlefile = getFileByID(id, subfilegroup.get(x));			if (singlefile != null) {				// File found in sub filegroup.				return singlefile;			}		}		return null;	}	/***************************************************************************	 * <p>	 * Parses an &lt;AmdSec&gt; section and retrieves the appropriate subsection	 * with the requested id.	 * </p>	 * 	 * @param inDoc	 *            MetsDocument, which contains the requested section	 * @param id	 * @param checkSubSections	 *            if set to true, all sub-section &lt;techMD&gt;,	 *            &lt;rightsMD&gt;,&lt;sourceMD&gt; and &lt;digiprovMD&gt; are	 *            checked, if one of those contains the required element. If set	 *            to false, only the appropriate &lt;AmdSec&gt; is retrieved.	 * @return	 **************************************************************************/	private Object getAmdSecByID(String id, boolean checkSubSections) {		MdSecType result = null;		// Get all descriptive Metadata sections as an array.		List<AmdSecType> mdsections = this.mets.getAmdSecList();		// Iterate over all sections.		for (int i = 0; i < mdsections.size(); i++) {			AmdSecType mdsec = mdsections.get(i);			String sectionid = mdsec.getID();			// Compare the id and the given ID.			if (sectionid.equals(id)) {				return mdsec;			}			if (checkSubSections) {				List<MdSecType> mdsec_rights = mdsec.getRightsMDList();				List<MdSecType> mdsec_source = mdsec.getSourceMDList();				List<MdSecType> mdsec_tech = mdsec.getTechMDList();				List<MdSecType> mdsec_digiprov = mdsec.getDigiprovMDList();				result = getMdSecTypeByID(mdsec_rights, id);				if (result != null) {					return result;				}				result = getMdSecTypeByID(mdsec_source, id);				if (result != null) {					return result;				}				result = getMdSecTypeByID(mdsec_tech, id);				if (result != null) {					return result;				}				result = getMdSecTypeByID(mdsec_digiprov, id);				if (result != null) {					return result;				}			}		}		return null;	}	/***************************************************************************	 * <p>	 * Creates an MdWrap element under the given MdSecType object of a certain	 * type. The following values.	 * </p>	 * 	 * <p>	 * For mdTypeValue are supported:	 * 	 * <ul>	 * <li>dc - creates DC value for DublinCore</li>	 * <li>dc - creates DC value for DublinCore</li>	 * <li>ddi - creates DDI value</li>	 * <li>ead - creates EAD value for Encoded Archival Description</li>	 * <li>fgdc - creates FGDC value</li>	 * <li>lc_av - creates LCAV value for Library of Congress audio video	 * project</li>	 * <li>lom - creates LOM value for learning objects metadata</li>	 * <li>marc - creates MARC value</li>	 * <li>mods - creates MODS value</li>	 * <li>nisoimg - creates NISOIMG value NISO technical metadata for still	 * images (MIX)</li>	 * <li>premis - creates PREMIS value</li>	 * <li>teihdr - creates TEIHDR value for metadata from the TEI header</li>	 * <li>vra - creates VRA value</li>	 * </ul>	 * 	 * In case mdTypeValue has none of the above values, the value is stored in	 * the OTHERMDTYPE attribute and MDTYPE is set to "other".	 * </p>	 * 	 * @param inMDSec	 * @param mdTypeValue	 * @return MdWrap element	 **************************************************************************/	private MdWrap createMDWrap(MdSecType inMDSec, String mdTypeValue) {		MdWrap mdwrap = inMDSec.addNewMdWrap();		MdSecType.MdWrap.MDTYPE.Enum mdtype = null;		if (mdTypeValue.equalsIgnoreCase("dc")) {			mdtype = MdSecType.MdWrap.MDTYPE.DC;		}		if (mdTypeValue.equalsIgnoreCase("ddi")) {			mdtype = MdSecType.MdWrap.MDTYPE.DDI;		}		if (mdTypeValue.equalsIgnoreCase("ead")) {			mdtype = MdSecType.MdWrap.MDTYPE.EAD;		}		if (mdTypeValue.equalsIgnoreCase("fgdc")) {			mdtype = MdSecType.MdWrap.MDTYPE.FGDC;		}		if (mdTypeValue.equalsIgnoreCase("lc_av")) {			mdtype = MdSecType.MdWrap.MDTYPE.LC_AV;		}		if (mdTypeValue.equalsIgnoreCase("lom")) {			mdtype = MdSecType.MdWrap.MDTYPE.LOM;		}		if (mdTypeValue.equalsIgnoreCase("marc")) {			mdtype = MdSecType.MdWrap.MDTYPE.MARC;		}		if (mdTypeValue.equalsIgnoreCase("mods")) {			mdtype = MdSecType.MdWrap.MDTYPE.MODS;		}		if (mdTypeValue.equalsIgnoreCase("nisoimg")) {			mdtype = MdSecType.MdWrap.MDTYPE.NISOIMG;		}		if (mdTypeValue.equalsIgnoreCase("premis")) {			mdtype = MdSecType.MdWrap.MDTYPE.PREMIS;		}		if (mdTypeValue.equalsIgnoreCase("teihdr")) {			mdtype = MdSecType.MdWrap.MDTYPE.TEIHDR;		}		if (mdTypeValue.equalsIgnoreCase("vra")) {			mdtype = MdSecType.MdWrap.MDTYPE.VRA;		}		if (mdtype == null) {			mdtype = MdSecType.MdWrap.MDTYPE.OTHER;		}		mdwrap.setMDTYPE(mdtype);		// If the type is none of the above, we create an OTHERMDTYPE attribute.		if (mdtype == MdSecType.MdWrap.MDTYPE.OTHER) {			mdwrap.setOTHERMDTYPE(mdTypeValue);		}		return mdwrap;	}	/***************************************************************************	 * GETTERS AND SETTERS	 **************************************************************************/	/***************************************************************************	 * @return	 **************************************************************************/	public String getVersion() {		return version;	}}
+package gov.loc.mets;
+
+/*******************************************************************************
+ * gov.loc.mets / Helper.java
+ *
+ * Copyright 2010 Center for Retrospective Digitization, Göttingen (GDZ)
+ *
+ * http://gdz.sub.uni-goettingen.de
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This Library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ ******************************************************************************/
+
+import gov.loc.mets.DivType.Fptr;
+import gov.loc.mets.FileType.FLocat;
+import gov.loc.mets.MdSecType.MdWrap;
+import gov.loc.mets.MdSecType.MdWrap.XmlData;
+import gov.loc.mets.MetsType.FileSec;
+import gov.loc.mets.MetsType.StructLink;
+import gov.loc.mets.MetsType.FileSec.FileGrp;
+import gov.loc.mets.StructLinkType.SmLink;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.xmlbeans.XmlAnyURI;
+import org.apache.xmlbeans.XmlException;
+import org.apache.xmlbeans.XmlObject;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+/*******************************************************************************
+ * <p>
+ * Helper class to parse and create METS files more easily.
+ * </p>
+ *
+ * @author Markus Enders
+ * @version 2009-10-21
+ * @since Jan 2007
+ *
+ *        TODOLOG
+ *
+ *        TODO This should be a seperate maven project!
+ *
+ *        TODO Update the HelperTest class and use it for JUnit tests!
+ *
+ *        CHANGELOG
+ *
+ *        21.10.2009 --- Funk --- Refactored some conditionals.
+ *
+ *        20.10.2009 --- Funk --- Added method for retrieving DivTypes by
+ *        DivType ID --- Corrected some typos.
+ *
+ ******************************************************************************/
+
+public class Helper {
+
+	/***************************************************************************
+	 * STATIC FINALS
+	 **************************************************************************/
+
+	private final static String	version		= "0.2-20091021";
+
+	// Define.
+	private final static int	DIGIPROVMD	= 1;
+	private final static int	RIGHTSMD	= 2;
+	private final static int	TECHMD		= 3;
+	private final static int	SOURCEMD	= 4;
+
+	/***************************************************************************
+	 * INSTANCE VARIABLES
+	 **************************************************************************/
+
+	// The Mets wrapper element <mets>.
+	private MetsType			mets;
+
+	/***************************************************************************
+	 * CONSTRUCTORS
+	 **************************************************************************/
+
+	/***************************************************************************
+	 * <p>
+	 * Default Constructor.
+	 * </p>
+	 *
+	 * @param inMets
+	 **************************************************************************/
+	public Helper(MetsType inMets) {
+		this.mets = inMets;
+	}
+
+	/***************************************************************************
+	 * WHAT THE OBJECT DOES
+	 **************************************************************************/
+
+	/***************************************************************************
+	 * @param inDiv
+	 * @param inContent
+	 * @return
+	 **************************************************************************/
+	public MdSecType addDmdSecType(DivType inDiv, String inContent) {
+		LinkedList<String> l1 = null;
+		MdSecType newDmdSecType = createDescriptiveMetadata(inContent);
+
+		// Happens, when inContent is XML compliant.
+		if (newDmdSecType == null) {
+			return null;
+		}
+
+		// Get ID of newDmdSecType.
+		String newID = newDmdSecType.getID();
+
+		// Add this id to the inDiv.
+		List<String> l = inDiv.getDMDID();
+
+		if (l == null) {
+			l1 = new LinkedList<String>();
+		} else {
+			l1 = new LinkedList<String>(l);
+		}
+
+		l1.add(newID);
+		inDiv.setDMDID(l1);
+
+		return newDmdSecType;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Creates a new DmdSec object for a given DivType. Cause the content is
+	 * transmitted as a byte-array, it will be regarded as binary content.
+	 * Therefore an &lt;binData&gt; element will be created.<br/>
+	 *
+	 * The method will construct an internal unique identifier for the DmdSec
+	 * automatically and will add this identifier to the &lt;div&gt;.
+	 * </p>
+	 *
+	 * @param inDiv
+	 *            the &lt;div&gt; element, which will conntect
+	 * @param inContent
+	 *            a byte-array containing the binary content.
+	 * @return
+	 **************************************************************************/
+	public MdSecType addDmdSecType(DivType inDiv, byte[] inContent) {
+		LinkedList<String> l1 = null;
+
+		MdSecType newDmdSecType = createDescriptiveMetadata(inContent);
+
+		// Get ID of newDmdSecType.
+		String newID = newDmdSecType.getID();
+
+		// Add this id to the inDiv.
+		List<String> l = inDiv.getDMDID();
+
+		if (l == null) {
+			l1 = new LinkedList<String>();
+		} else {
+			l1 = new LinkedList<String>(l);
+		}
+
+		l1.add(newID);
+		inDiv.setDMDID(l1);
+
+		return newDmdSecType;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Creates a new DMDSec with xml compliant content. Identifier for the
+	 * DMDSec is created automatically.
+	 * </p>
+	 *
+	 * @param mets
+	 * @param content
+	 *            content must be xml compliant
+	 * @return
+	 **************************************************************************/
+	private MdSecType createDescriptiveMetadata(String content) {
+		String dmdid_string = createNewXMLID("dmdsec");
+
+		// Create descriptive metadata section.
+		MdSecType dmdSec = this.mets.addNewDmdSec();
+		dmdSec.setID(dmdid_string);
+
+		// Check, if inContent is XML compliant or not create an xmlData
+		// section, if it is xml compliant, otherwise a binData section.
+
+		// Create a new <MdWrap> element.
+		MdSecType.MdWrap mdwrap = dmdSec.addNewMdWrap();
+
+		// Create new <xmlData> element. We have to create DOM node, to avoid
+		// having a schema for the xml content; for xmlbeans a schema and the
+		// derived classes are a must.
+		MdSecType.MdWrap.XmlData xml = mdwrap.addNewXmlData();
+
+		Node xmlnode = xml.getDomNode();
+		Document domdocument = xmlnode.getOwnerDocument();
+		Node contentnode = domdocument.createTextNode(content);
+		xmlnode.appendChild(contentnode);
+
+		// XmlObject xo = null;
+		// try {
+		// xo = XmlObject.Factory.parse(content);
+		// } catch (XmlException e) {
+		// e.printStackTrace();
+		// return null;
+		// }
+		// // XmlString implements the XmlObject interface; therefore it can be
+		// // added to the <XmlData> element XmlData object.
+		// xml.set(xo);
+
+		return dmdSec;
+	}
+
+	/***************************************************************************
+	 * @param inDocument
+	 *            another xml-document, e.g. ModsDocument etc.
+	 * @return
+	 **************************************************************************/
+	private MdSecType createDescriptiveMetadata(XmlObject inDocument) {
+		// Create identifier.
+		String dmdid_string = createNewXMLID("dmdsec");
+
+		// Create descriptive metadata section.
+		MdSecType dmdSec = this.mets.addNewDmdSec();
+		dmdSec.setID(dmdid_string);
+
+		// Ccheck, if inContent is XML compliant or not create an xmlData
+		// section, if it is xml compliant otherwise a binData section.
+
+		// Create a new <MdWrap> element.
+		MdSecType.MdWrap mdwrap = dmdSec.addNewMdWrap();
+
+		// Ccreate new <xmlData> element.
+		MdSecType.MdWrap.XmlData xml = mdwrap.addNewXmlData();
+
+		// Any Document implements the XmlObject interface; therefore it can be
+		// added to the <XmlData> element / XmlData object.
+		xml.set(inDocument);
+
+		return dmdSec;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Creates a new DMDSec with binary content.
+	 * </p>
+	 *
+	 * @param mets
+	 * @param content
+	 * @return
+	 **************************************************************************/
+	private MdSecType createDescriptiveMetadata(byte[] content) {
+		String dmdid_string = createNewXMLID("dmdsec");
+
+		// Create descriptive metadata section.
+		MdSecType dmdSec = this.mets.addNewDmdSec();
+		dmdSec.setID(dmdid_string);
+
+		// Check, if inContent is XML compliant or not create an xmlData
+		// section, if it is xml compliant otherwise a binData section.
+
+		// Create a new <MdWrap> element.
+		MdSecType.MdWrap mdwrap = dmdSec.addNewMdWrap();
+		mdwrap.setBinData(content);
+
+		return dmdSec;
+	}
+
+	/***************************************************************************
+	 * @param content
+	 * @param mdTypeValue
+	 * @param mdPart
+	 * @return
+	 **************************************************************************/
+	public MdSecType addAmdSecType(XmlObject content, String mdTypeValue,
+			int mdPart) {
+		MdSecType result = null;
+		AmdSecType amdsec = this.mets.addNewAmdSec();
+
+		// Create identifier for amdsec.
+		String amdid = createNewXMLID("amdsec");
+		amdsec.setID(amdid);
+
+		// Create subsection and create id for the subsection.
+		String id = null;
+
+		if (mdPart == DIGIPROVMD) {
+			result = amdsec.addNewDigiprovMD();
+			id = createNewXMLID("digiprov");
+		} else if (mdPart == RIGHTSMD) {
+			result = amdsec.addNewRightsMD();
+			id = createNewXMLID("rights");
+		} else if (mdPart == TECHMD) {
+			result = amdsec.addNewTechMD();
+			id = createNewXMLID("tech");
+		} else if (mdPart == SOURCEMD) {
+			result = amdsec.addNewSourceMD();
+			id = createNewXMLID("source");
+		} else {
+			// Unknown type, should really throw an exception here.
+			return null;
+		}
+
+		// Create identifier for result.
+		result.setID(id);
+		MdWrap mdwrap = createMDWrap(result, mdTypeValue);
+
+		// Add content.
+		XmlData xmldata = mdwrap.addNewXmlData();
+		xmldata.set(content);
+		return result;
+	}
+
+	/***************************************************************************
+	 * @param content
+	 * @param mdTypeValue
+	 * @param mdPart
+	 * @return
+	 * @throws XmlException
+	 **************************************************************************/
+	public MdSecType addAmdSecType(String content, String mdTypeValue,
+			int mdPart) {
+		MdSecType result = null;
+		AmdSecType amdsec = this.mets.addNewAmdSec();
+
+		// Create identifier for amdsec.
+		String amdid = createNewXMLID("amdsec");
+		amdsec.setID(amdid);
+
+		// Create subsection and create id for the subsection.
+		String id = null;
+
+		if (mdPart == DIGIPROVMD) {
+			result = amdsec.addNewDigiprovMD();
+			id = createNewXMLID("digiprov");
+		} else if (mdPart == RIGHTSMD) {
+			result = amdsec.addNewRightsMD();
+			id = createNewXMLID("rights");
+		} else if (mdPart == TECHMD) {
+			result = amdsec.addNewTechMD();
+			id = createNewXMLID("tech");
+		} else if (mdPart == SOURCEMD) {
+			result = amdsec.addNewSourceMD();
+			id = createNewXMLID("source");
+		} else {
+			// Unknown type, should really throw an exception here.
+			return null;
+		}
+
+		// Create identifier for result.
+		result.setID(id);
+		MdWrap mdwrap = createMDWrap(result, mdTypeValue);
+
+		// Add content.
+		XmlData xmldata = mdwrap.addNewXmlData();
+
+		// We have to create DOM node, to avoid having a schema for the xml
+		// content; for xmlbeans a schema and the derived classes are a must.
+
+		// Get DOM node.
+		Node xmlnode = xmldata.getDomNode();
+
+		Document domdocument = xmlnode.getOwnerDocument();
+		Node contentnode = domdocument.createTextNode(content);
+		xmlnode.appendChild(contentnode);
+
+		return result;
+	}
+
+	/***************************************************************************
+	 * @param content
+	 * @param mdTypeValue
+	 * @param mdPart
+	 * @return
+	 **************************************************************************/
+	public MdSecType addAmdSecType(byte[] content, String mdTypeValue,
+			int mdPart) {
+		MdSecType result = null;
+		AmdSecType amdsec = this.mets.addNewAmdSec();
+
+		// Ccreate identifier for amdsec.
+		String amdid = createNewXMLID("amdsec");
+		amdsec.setID(amdid);
+
+		// Create subsection and create id for the subsection.
+		String id = null;
+
+		if (mdPart == DIGIPROVMD) {
+			result = amdsec.addNewDigiprovMD();
+			id = createNewXMLID("digiprov");
+		} else if (mdPart == RIGHTSMD) {
+			result = amdsec.addNewRightsMD();
+			id = createNewXMLID("rights");
+		} else if (mdPart == TECHMD) {
+			result = amdsec.addNewTechMD();
+			id = createNewXMLID("tech");
+		} else if (mdPart == SOURCEMD) {
+			result = amdsec.addNewSourceMD();
+			id = createNewXMLID("source");
+		} else {
+			// Unknown type, should really throw an exception here.
+			return null;
+		}
+
+		// Create identifier for result.
+		result.setID(id);
+
+		MdWrap mdwrap = createMDWrap(result, mdTypeValue);
+
+		// Add content.
+		mdwrap.setBinData(content);
+
+		return result;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves the appropriate descriptive metadata section of a given type.
+	 * The type is stored in the TYPE-attribute. The comparison is case
+	 * sensitive.
+	 * </p>
+	 *
+	 * @param metsDoc
+	 *            the MetsDocument object
+	 * @param inDiv
+	 *            the DivType object
+	 * @param type
+	 *            the type as a string; type is case sensitive.
+	 * @return the MdSecType object, which matches . If several objects with the
+	 *         same type are available, the first one is returned.
+	 **************************************************************************/
+	public MdSecType getMetadataSectionByType(DivType inDiv, String type) {
+		// Get all IDs for administrative metadata sections.
+		List<String> allmdids = inDiv.getADMID();
+
+		if (allmdids == null) {
+			return null;
+		}
+
+		Iterator<String> it = allmdids.iterator();
+		while (it.hasNext()) {
+			String admid = it.next();
+
+			// Get section by ID verify the type of metadata.
+			MdSecType dmdSec = getDmdSecByID(admid);
+
+			// Get <mdWrap> element.
+			MdSecType.MdWrap mdwrap = dmdSec.getMdWrap();
+
+			if (mdwrap != null) {
+				MdSecType.MdWrap.MDTYPE.Enum e = mdwrap.getMDTYPE();
+				// Compare value of MDTYPE here.
+				if (e.equals(MdSecType.MdWrap.MDTYPE.OTHER)) {
+					String othermdtype = mdwrap.getOTHERMDTYPE();
+					// If it's PREMIS metadata.
+					if (othermdtype.equals(type)) {
+						// We found the LMER metadata type; create a PREMIS
+						// metadata for it.
+						return dmdSec;
+					}
+				}
+			}
+
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves a &lt;amdSec&gt; with a given ID; this ID is used to link from
+	 * the appropriate <div> element to the attached metadata.
+	 * </p>
+	 *
+	 * @param id
+	 *            xml-id
+	 * @return
+	 **************************************************************************/
+	public AmdSecType getAmdSecByID(String id) {
+		Object o = getAmdSecByID(id, false);
+
+		if (o != null) {
+			AmdSecType result = (AmdSecType) o;
+			return result;
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Gets the descriptive metadata section defined by the ID.
+	 * </p>
+	 *
+	 * @param inDoc
+	 *            the MetsDocument which should contain the DmdSec element
+	 * @param id
+	 *            unique ID of the descriptive metadata section
+	 * @return
+	 **************************************************************************/
+	public MdSecType getDmdSecByID(String id) {
+		// Get all descriptive Metadata sections as an array.
+		List<MdSecType> mdsections = this.mets.getDmdSecList();
+
+		// Iterate over all sections.
+		for (int i = 0; i < mdsections.size(); i++) {
+			MdSecType mdsec = mdsections.get(i);
+			String sectionid = mdsec.getID();
+
+			if (sectionid.equals(id)) { // compare the id and the given id
+				return mdsec;
+			}
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves the content of a descriptive/administrative metadata section;
+	 * if the metadata is referenced by a <mdRef> element, the data is loaded
+	 * via http (other protocols are currently unsupported.
+	 * </p>
+	 *
+	 * @param the
+	 *            appropriate MdSecType element to the <dmdSec>
+	 * @return the content of the section as a string
+	 * @throws IOException
+	 **************************************************************************/
+	public String getMdSecContents(MdSecType mdsec) throws IOException {
+		String result = null;
+
+		// Get mdWrap and mdRef elements.
+		MdSecType.MdRef mdref = mdsec.getMdRef();
+		MdSecType.MdWrap mdwrap = mdsec.getMdWrap();
+
+		if (mdref != null) {
+			// Get the http URL/URI.
+			XmlAnyURI uri = mdref.xgetHref();
+			// Convert the URI to String.
+			String uri_String = uri.toString();
+			// Make an HTTP request, the result of this request is returned as a
+			// string.
+			result = makeHTTPRequest(uri_String);
+		}
+
+		if (mdwrap != null) {
+			// Get xml-data and convert it to String.
+			MdSecType.MdWrap.XmlData xmldata = mdwrap.getXmlData();
+
+			result = xmldata.toString();
+		}
+
+		return result;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves all
+	 *
+	 * <pre>
+	 * StructMapType
+	 * </pre>
+	 *
+	 * objects of a given type.
+	 * </p>
+	 *
+	 * @param type
+	 * @return List containing StructMapType objects, if none was found null is
+	 *         returned.
+	 **************************************************************************/
+	public List<StructMapType> getStructMapByType(String type) {
+
+		List<StructMapType> resultList = new LinkedList<StructMapType>();
+		List<StructMapType> structmap = this.mets.getStructMapList();
+
+		for (int i = 0; i < structmap.size(); i++) {
+			if ((structmap.get(i).getTYPE() != null)
+					&& (structmap.get(i).getTYPE().equals(type))) {
+				resultList.add(structmap.get(i));
+			}
+		}
+
+		if (resultList.size() == 0) {
+			return null;
+		}
+
+		return resultList;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves all
+	 *
+	 * <pre>
+	 * StructMapType
+	 * </pre>
+	 *
+	 * objects with a given label.
+	 * </p>
+	 *
+	 * @param type
+	 * @return List containing StructMapType objects, if none was found null is
+	 *         returned
+	 **************************************************************************/
+	public List<StructMapType> getStructMapByLabel(String label) {
+		List<StructMapType> resultList = new LinkedList<StructMapType>();
+		List<StructMapType> structmap = this.mets.getStructMapList();
+
+		for (int i = 0; i < structmap.size(); i++) {
+			if ((structmap.get(i).getLABEL() != null)
+					&& (structmap.get(i).getLABEL().equals(label))) {
+				resultList.add(structmap.get(i));
+			}
+		}
+
+		if (resultList.size() == 0) {
+			return null;
+		}
+
+		return resultList;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves all
+	 *
+	 * <pre>
+	 * StructMapType
+	 * </pre>
+	 *
+	 * objects with a given ID.
+	 * </p>
+	 *
+	 * @param type
+	 * @return the StructMapType or null
+	 **************************************************************************/
+	public StructMapType getStructMapByID(String id) {
+		List<StructMapType> structmap = this.mets.getStructMapList();
+
+		for (int i = 0; i < structmap.size(); i++) {
+			if ((structmap.get(i).getID() != null)
+					&& (structmap.get(i).getID().equals(id))) {
+				return structmap.get(i);
+			}
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves a FileType object with the given ID.
+	 * </p>
+	 *
+	 * @param id
+	 * @return FileType object or null (if none available)
+	 **************************************************************************/
+	public FileType getFileByID(String id) {
+
+		FileSec filesec = this.mets.getFileSec();
+		List<FileGrp> filegroup = filesec.getFileGrpList();
+
+		// Iterate over all filegroups.
+		for (int i = 0; i < filegroup.size(); i++) {
+			FileType file = getFileByID(id, filegroup.get(i));
+
+			if (file != null) {
+				return file;
+			}
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves all &lt;div&gt; elements, which are linked to a given
+	 * &lt;div&gt; element in the structLink-section, no matter if the
+	 * relationship points to or from the given &lt;div&gt; element.
+	 * </p>
+	 *
+	 * @param inDiv
+	 * @return
+	 **************************************************************************/
+	public List<SmLink> getAllLinkedDivs(DivType inDiv) {
+		return getAllLinkedDivs(inDiv, true, true);
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves all &lt;div&gt; elements, which point to the given &lt;div&gt;
+	 * element in the structLink section.
+	 * </p>
+	 *
+	 * @param inDiv
+	 * @return
+	 **************************************************************************/
+	public List<SmLink> getAllLinkedFromDivs(DivType inDiv) {
+		return getAllLinkedDivs(inDiv, false, true);
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves all &lt;div&gt; elements, which point from the given
+	 * &lt;div&gt; element in the structLink section.
+	 * </p>
+	 *
+	 * @param inDiv
+	 * @return
+	 **************************************************************************/
+	public List<SmLink> getAllLinkedToDivs(DivType inDiv) {
+		return getAllLinkedDivs(inDiv, true, false);
+	}
+
+	/**************************************************************************
+	 * <p>
+	 * Gets a StructMap div type by the given div ID.
+	 * </p>
+	 *
+	 * @param theId
+	 * @param theDiv
+	 * @return The appropriate StructMap if existing, NULL otherwise.
+	 **************************************************************************/
+	public DivType getStructMapDiv(String theId) {
+
+		// Go through all StructMaps.
+		for (StructMapType smt : this.mets.getStructMapList()) {
+			// Call the private method recursively for every first StructMap div
+			// (only one is allowed here!).
+			return getStructMapDiv(theId, smt.getDiv());
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Creates a <file> object as the last object in a given <FileGrp>. The
+	 * <file> object will have a new, unique ID attribute and a single <FLocat>
+	 * sub element. The LOCTYPE attribute is filled automatically, depending on
+	 * the value of the file's location.
+	 * </p>
+	 *
+	 * @param inDiv
+	 * @param filegroup
+	 * @param url
+	 * @return FileType object, which represents the new <file> element.
+	 **************************************************************************/
+	public FileType createFileType(DivType inDiv, FileGrp filegroup, String url) {
+		// Ccreate new FileType.
+		FileType ft = filegroup.addNewFile();
+
+		// Add <mets:FLocat> element.
+		FLocat filelocation = ft.addNewFLocat();
+
+		if (url.startsWith("http")) {
+			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.URL);
+		} else if (url.startsWith("doi")) {
+			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.DOI);
+		} else if (url.startsWith("handle")) {
+			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.HANDLE);
+		} else if (url.startsWith("urn")) {
+			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.URN);
+		} else {
+			filelocation.setLOCTYPE(FileType.FLocat.LOCTYPE.OTHER);
+		}
+
+		// Set URL; create identifier for file and add one.
+		filelocation.setHref(url);
+		String fileidentifier = "";
+		// Set file pointer for the new <file> element.
+		ft.setID(fileidentifier);
+		Fptr filepointer = inDiv.addNewFptr();
+		// Set fileidentifier.
+		filepointer.setFILEID(fileidentifier);
+
+		return ft;
+	}
+
+	/***************************************************************************
+	 * PRIVATE (AND PROTECTED) METHODS
+	 **************************************************************************/
+
+	/***************************************************************************
+	 * <p>
+	 * Private class, which is used by
+	 *
+	 * <pre>
+	 * getAMDSecByID
+	 * </pre>
+	 *
+	 * method. From an array of MdSecType objects it finds the one with the
+	 * given ID.<br/>
+	 *
+	 * Usually.
+	 * </p>
+	 *
+	 * @param inMDsec
+	 * @param inID
+	 * @return an MdSecType object
+	 **************************************************************************/
+	private MdSecType getMdSecTypeByID(List<MdSecType> inMDsec, String inID) {
+		for (int i = 0; i < inMDsec.size(); i++) {
+			MdSecType current = inMDsec.get(i);
+			String id = current.getID();
+
+			if ((id != null) && (id.equals(inID))) {
+				return current;
+			}
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * @param type
+	 * @return
+	 **************************************************************************/
+	private String createNewXMLID(String type) {
+		String xmlid = null;
+		UUID uuid = UUID.randomUUID();
+		String uuidstring = uuid.toString();
+
+		if (type.equals("amdsec")) {
+			xmlid = "amd" + uuidstring;
+		} else if (type.equals("dmdsec")) {
+			xmlid = "dmd" + uuidstring;
+		} else if (type.equals("tech")) {
+			xmlid = "tech" + uuidstring;
+		} else if (type.equals("digiprov")) {
+			xmlid = "dipr" + uuidstring;
+		} else if (type.equals("rights")) {
+			xmlid = "rgt" + uuidstring;
+		} else if (type.equals("source")) {
+			xmlid = "src" + uuidstring;
+		} else if (type.equals("file")) {
+			xmlid = "fl" + uuidstring;
+		}
+
+		return xmlid;
+	}
+
+	/**************************************************************************
+	 * <p>
+	 * Gets a StructMap div type by the given ID and a given div.
+	 * </p>
+	 *
+	 * @param theId
+	 * @param theDiv
+	 * @return The appropriate StructMap if existing, NULL otherwise.
+	 **************************************************************************/
+	private DivType getStructMapDiv(String theId, DivType theDiv) {
+
+		// Firt check the given div type.
+		if (theDiv.getID().equals(theId)) {
+			return theDiv;
+		}
+
+		// Then check all divs from the the div list, if existing.
+		for (DivType dt : theDiv.getDivList()) {
+			DivType result = getStructMapDiv(theId, dt);
+
+			if (result != null) {
+				return result;
+			}
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Makes a simple HTTP call to a URI; this method is used for internal
+	 * purposes only. The content of the request is returned as a string.
+	 * </p>
+	 *
+	 * @param uri
+	 * @return
+	 * @throws IOException
+	 **************************************************************************/
+	private String makeHTTPRequest(String uri) throws IOException {
+
+		URL url;
+		URLConnection urlConn = null;
+		String str;
+
+		url = new URL(uri);
+		urlConn = url.openConnection();
+
+		// Get response data.
+		DataInputStream input = new DataInputStream(urlConn.getInputStream());
+
+		while (null != ((str = input.readLine()))) {
+			// Do nothing!
+		}
+
+		return str;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves all &lt;div&gt; elements which are linked to a given
+	 * &lt;div&gt; (inDiv) using the &lt;structLink&gt; section. Depending on
+	 * the checkto and checkfrom switches, the linked &lt;div&gt; elements are
+	 * only searched in the "to" or in the "from" attribute of the
+	 * &lt;smLink&gt; element.
+	 * </p>
+	 *
+	 * @param inDiv
+	 *            the &lt;div&gt; element for which all linked &lt;div&gt;
+	 *            elements should be found.
+	 * @param checkto
+	 * @param checkfrom
+	 * @return
+	 **************************************************************************/
+	private List<SmLink> getAllLinkedDivs(DivType inDiv, boolean checkto,
+			boolean checkfrom) {
+
+		LinkedList<SmLink> result = new LinkedList<SmLink>();
+
+		// Get ID for inDiv, this ID is used as a target.
+		String divid = inDiv.getID();
+
+		if (divid == null) {
+			// Has no ID attribute; can't neither source nor target of an smlink
+			// element.
+			return null;
+		}
+
+		// Get structLink section.
+		StructLink structlink = this.mets.getStructLink();
+		List<SmLink> links = structlink.getSmLinkList();
+
+		for (int i = 0; i < links.size(); i++) {
+			boolean from = false;
+			boolean to = false;
+
+			if (checkfrom && links.get(i).getFrom() != null
+					&& links.get(i).getFrom().equals(divid)) {
+				from = true;
+			} else if (checkfrom && (links.get(i).getFrom() == null)
+					|| !links.get(i).getFrom().equals(divid)) {
+				// Checkfrom should be checked, but was not equal.
+				from = false;
+			} else {
+				// Checkfrom ist false, from field is not beeing tested.
+				from = true;
+			}
+
+			if (checkto && links.get(i).getTo() != null
+					&& links.get(i).getTo().equals(divid)) {
+				to = true;
+			} else if (checkto && (links.get(i).getTo() == null)
+					|| !links.get(i).getTo().equals(divid)) {
+				// Checkfrom should be checked, but was not equal.
+				to = false;
+			} else {
+				// checkto ist false, to field is not beeing tested.
+				to = true;
+			}
+
+			if (from && to) {
+				// In either the from or the two link.
+				result.add(links.get(i));
+			}
+		}
+
+		// No hits, return null.
+		if (result.size() == 0) {
+			return null;
+		}
+
+		return result;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Retrieves a file by ID from a filegroup, including all sub filegroups.
+	 * </p>
+	 *
+	 * @param id
+	 * @param filegroup
+	 * @return a FileType or null
+	 **************************************************************************/
+	private FileType getFileByID(String id, FileGrpType filegroup) {
+
+		// Iterate over all files.
+		List<FileType> file = filegroup.getFileList();
+
+		for (int i = 0; i < file.size(); i++) {
+			if ((file.get(i).getID() != null)
+					&& (file.get(i).getID().equals(id))) {
+				// Found the type.
+				return file.get(i);
+			}
+		}
+
+		// Nothing found, so get the list of all sub groups and iterate over
+		// those subgroups.
+		List<FileGrpType> subfilegroup = filegroup.getFileGrpList();
+
+		for (int x = 0; x < subfilegroup.size(); x++) {
+			FileType singlefile = getFileByID(id, subfilegroup.get(x));
+
+			if (singlefile != null) {
+				// File found in sub filegroup.
+				return singlefile;
+			}
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Parses an &lt;AmdSec&gt; section and retrieves the appropriate subsection
+	 * with the requested id.
+	 * </p>
+	 *
+	 * @param inDoc
+	 *            MetsDocument, which contains the requested section
+	 * @param id
+	 * @param checkSubSections
+	 *            if set to true, all sub-section &lt;techMD&gt;,
+	 *            &lt;rightsMD&gt;,&lt;sourceMD&gt; and &lt;digiprovMD&gt; are
+	 *            checked, if one of those contains the required element. If set
+	 *            to false, only the appropriate &lt;AmdSec&gt; is retrieved.
+	 * @return
+	 **************************************************************************/
+	private Object getAmdSecByID(String id, boolean checkSubSections) {
+		MdSecType result = null;
+
+		// Get all descriptive Metadata sections as an array.
+		List<AmdSecType> mdsections = this.mets.getAmdSecList();
+
+		// Iterate over all sections.
+		for (int i = 0; i < mdsections.size(); i++) {
+			AmdSecType mdsec = mdsections.get(i);
+			String sectionid = mdsec.getID();
+
+			// Compare the id and the given ID.
+			if (sectionid.equals(id)) {
+				return mdsec;
+			}
+
+			if (checkSubSections) {
+				List<MdSecType> mdsec_rights = mdsec.getRightsMDList();
+				List<MdSecType> mdsec_source = mdsec.getSourceMDList();
+				List<MdSecType> mdsec_tech = mdsec.getTechMDList();
+				List<MdSecType> mdsec_digiprov = mdsec.getDigiprovMDList();
+
+				result = getMdSecTypeByID(mdsec_rights, id);
+				if (result != null) {
+					return result;
+				}
+
+				result = getMdSecTypeByID(mdsec_source, id);
+				if (result != null) {
+					return result;
+				}
+
+				result = getMdSecTypeByID(mdsec_tech, id);
+				if (result != null) {
+					return result;
+				}
+
+				result = getMdSecTypeByID(mdsec_digiprov, id);
+				if (result != null) {
+					return result;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Creates an MdWrap element under the given MdSecType object of a certain
+	 * type. The following values.
+	 * </p>
+	 *
+	 * <p>
+	 * For mdTypeValue are supported:
+	 *
+	 * <ul>
+	 * <li>dc - creates DC value for DublinCore</li>
+	 * <li>dc - creates DC value for DublinCore</li>
+	 * <li>ddi - creates DDI value</li>
+	 * <li>ead - creates EAD value for Encoded Archival Description</li>
+	 * <li>fgdc - creates FGDC value</li>
+	 * <li>lc_av - creates LCAV value for Library of Congress audio video
+	 * project</li>
+	 * <li>lom - creates LOM value for learning objects metadata</li>
+	 * <li>marc - creates MARC value</li>
+	 * <li>mods - creates MODS value</li>
+	 * <li>nisoimg - creates NISOIMG value NISO technical metadata for still
+	 * images (MIX)</li>
+	 * <li>premis - creates PREMIS value</li>
+	 * <li>teihdr - creates TEIHDR value for metadata from the TEI header</li>
+	 * <li>vra - creates VRA value</li>
+	 * </ul>
+	 *
+	 * In case mdTypeValue has none of the above values, the value is stored in
+	 * the OTHERMDTYPE attribute and MDTYPE is set to "other".
+	 * </p>
+	 *
+	 * @param inMDSec
+	 * @param mdTypeValue
+	 * @return MdWrap element
+	 **************************************************************************/
+	private MdWrap createMDWrap(MdSecType inMDSec, String mdTypeValue) {
+		MdWrap mdwrap = inMDSec.addNewMdWrap();
+		MdSecType.MdWrap.MDTYPE.Enum mdtype = null;
+
+		if (mdTypeValue.equalsIgnoreCase("dc")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.DC;
+		}
+		if (mdTypeValue.equalsIgnoreCase("ddi")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.DDI;
+		}
+		if (mdTypeValue.equalsIgnoreCase("ead")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.EAD;
+		}
+		if (mdTypeValue.equalsIgnoreCase("fgdc")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.FGDC;
+		}
+		if (mdTypeValue.equalsIgnoreCase("lc_av")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.LC_AV;
+		}
+		if (mdTypeValue.equalsIgnoreCase("lom")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.LOM;
+		}
+		if (mdTypeValue.equalsIgnoreCase("marc")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.MARC;
+		}
+		if (mdTypeValue.equalsIgnoreCase("mods")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.MODS;
+		}
+		if (mdTypeValue.equalsIgnoreCase("nisoimg")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.NISOIMG;
+		}
+		if (mdTypeValue.equalsIgnoreCase("premis")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.PREMIS;
+		}
+		if (mdTypeValue.equalsIgnoreCase("teihdr")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.TEIHDR;
+		}
+		if (mdTypeValue.equalsIgnoreCase("vra")) {
+			mdtype = MdSecType.MdWrap.MDTYPE.VRA;
+		}
+		if (mdtype == null) {
+			mdtype = MdSecType.MdWrap.MDTYPE.OTHER;
+		}
+
+		mdwrap.setMDTYPE(mdtype);
+
+		// If the type is none of the above, we create an OTHERMDTYPE attribute.
+		if (mdtype == MdSecType.MdWrap.MDTYPE.OTHER) {
+			mdwrap.setOTHERMDTYPE(mdTypeValue);
+		}
+
+		return mdwrap;
+	}
+
+	/***************************************************************************
+	 * GETTERS AND SETTERS
+	 **************************************************************************/
+
+	/***************************************************************************
+	 * @return
+	 **************************************************************************/
+	public String getVersion() {
+		return version;
+	}
+
+}

--- a/ugh/src/gov/loc/mets/Helper.java
+++ b/ugh/src/gov/loc/mets/Helper.java
@@ -57,7 +57,7 @@ import org.w3c.dom.Node;
  *
  *        TODOLOG
  *
- *        TODO This should be a seperate maven project!
+ *        TODO This should be a separate maven project!
  *
  *        TODO Update the HelperTest class and use it for JUnit tests!
  *
@@ -962,7 +962,7 @@ public class Helper {
 				// Checkfrom should be checked, but was not equal.
 				from = false;
 			} else {
-				// Checkfrom ist false, from field is not beeing tested.
+				// Checkfrom ist false, from field is not being tested.
 				from = true;
 			}
 
@@ -974,7 +974,7 @@ public class Helper {
 				// Checkfrom should be checked, but was not equal.
 				to = false;
 			} else {
-				// checkto ist false, to field is not beeing tested.
+				// checkto ist false, to field is not being tested.
 				to = true;
 			}
 

--- a/ugh/src/gov/loc/mets/HelperTest.java
+++ b/ugh/src/gov/loc/mets/HelperTest.java
@@ -1,1 +1,146 @@
-package gov.loc.mets;/******************************************************************************* * gov.loc.mets / HelperTest.java *  * Copyright 2010 Center for Retrospective Digitization, Göttingen (GDZ) *  * http://gdz.sub.uni-goettingen.de *  * This program is free software; you can redistribute it and/or modify it * under the terms of the GNU Lesser General Public License as published by * the Free Software Foundation; either version 3 of the License, or (at your * option) any later version. *  * This Library is distributed in the hope that it will be useful, but WITHOUT * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License * for more details. *  * You should have received a copy of the GNU Lesser General Public License * along with this library; if not, write to the Free Software Foundation, * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA. ******************************************************************************/import gov.loc.mets.MetsType.MetsHdr;import gov.loc.mets.MetsType.MetsHdr.Agent;import java.io.File;import java.io.IOException;import java.util.HashMap;import org.apache.xmlbeans.XmlOptions;/*************************************************************************** * @author Markus Enders *  *         TODO: This class should probably be covered by a unit test. **************************************************************************/public class HelperTest {	/**************************************************************************	 * @param args	 **************************************************************************/	public static void main(String[] args) {		// TODO Auto-generated method stub		HelperTest ht = new HelperTest();		ht.createMets();	}	/***************************************************************************	 * <p>	 * Constructor.	 * </p>	 **************************************************************************/	public HelperTest() {		//	}	/**************************************************************************	 * 	 **************************************************************************/	public void createMets() {		// HashMap to store prefixes for different namespaces.		HashMap<String, String> suggestedPrefixes = new HashMap<String, String>();		XmlOptions opts = new XmlOptions();		// Create a METS wrapper		//		MetsDocument metsDocument = MetsDocument.Factory.newInstance();		// This is the <mets> element.		MetsType myMets = metsDocument.addNewMets();		// create header		//		// <MetsHdr>		// <agent>		// <name></name>		// <note></note>		// </agent>		// </MetsHdr>		MetsHdr header = myMets.addNewMetsHdr();		Agent metsAgent = header.addNewAgent();		metsAgent.setROLE(MetsType.MetsHdr.Agent.ROLE.CREATOR);		metsAgent.setTYPE(MetsType.MetsHdr.Agent.TYPE.INDIVIDUAL);		metsAgent.setName("Markus Enders");		metsAgent.addNote("He is the the METS-api to create this file");		// Create first div; therefore we have to add a new struct map; while		// adding this structMap a StructMapType object is created.		//		// Create a new <StructMap> element.		StructMapType sm = myMets.addNewStructMap();		// Create first div.		DivType monograph_div = sm.addNewDiv();		// This div is a monograph.		monograph_div.setTYPE("Monograph");		// This ID must be XML compliant.		monograph_div.setID("MAINDIV01");		monograph_div.setLABEL("Monograph");		// Create metadata for the first div.		//		// Ceate the xml metadata first.		StringBuffer xmlmetadata = new StringBuffer();		// Set the namespace for the MODS part.		suggestedPrefixes.put("http://purl.org/DC#", "dc");		xmlmetadata				.append("<dc:identifier xmlns:dc=\"http://purl.org/DC#\"></dc:identifier>");		xmlmetadata.append("<dc:title></dc:title>");		// create binary metadata (e.g. orig. MARC record)		StringBuffer binmetadata = new StringBuffer();		binmetadata.append("Binary Data");		// Creating metadata is difficult, since it can be therefore we use the		// helper class from level 2 api.		Helper h = new Helper(myMets);		h.addDmdSecType(monograph_div, xmlmetadata.toString());		h.addDmdSecType(monograph_div, binmetadata.toString().getBytes());		// Save METS as file, but create options.		opts.setSaveSuggestedPrefixes(suggestedPrefixes);		// Save file using the given options.		File outputFile = new File("C:/myMets.xml");		try {			metsDocument.save(outputFile, opts);		} catch (IOException e) {			// TODO Auto-generated catch block			e.printStackTrace();		}	}	/**************************************************************************	 * 	 **************************************************************************/	public void createMetsHeader() {		//	}}
+package gov.loc.mets;
+
+/*******************************************************************************
+ * gov.loc.mets / HelperTest.java
+ *
+ * Copyright 2010 Center for Retrospective Digitization, Göttingen (GDZ)
+ *
+ * http://gdz.sub.uni-goettingen.de
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This Library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ ******************************************************************************/
+
+import gov.loc.mets.MetsType.MetsHdr;
+import gov.loc.mets.MetsType.MetsHdr.Agent;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.apache.xmlbeans.XmlOptions;
+
+/***************************************************************************
+ * @author Markus Enders
+ *
+ *         TODO: This class should probably be covered by a unit test.
+ **************************************************************************/
+public class HelperTest {
+
+	/**************************************************************************
+	 * @param args
+	 **************************************************************************/
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		HelperTest ht = new HelperTest();
+		ht.createMets();
+	}
+
+	/***************************************************************************
+	 * <p>
+	 * Constructor.
+	 * </p>
+	 **************************************************************************/
+	public HelperTest() {
+		//
+	}
+
+	/**************************************************************************
+	 *
+	 **************************************************************************/
+	public void createMets() {
+		// HashMap to store prefixes for different namespaces.
+		HashMap<String, String> suggestedPrefixes = new HashMap<String, String>();
+		XmlOptions opts = new XmlOptions();
+
+		// Create a METS wrapper
+		//
+		MetsDocument metsDocument = MetsDocument.Factory.newInstance();
+
+		// This is the <mets> element.
+		MetsType myMets = metsDocument.addNewMets();
+
+		// create header
+		//
+		// <MetsHdr>
+		// <agent>
+		// <name></name>
+		// <note></note>
+		// </agent>
+		// </MetsHdr>
+
+		MetsHdr header = myMets.addNewMetsHdr();
+		Agent metsAgent = header.addNewAgent();
+		metsAgent.setROLE(MetsType.MetsHdr.Agent.ROLE.CREATOR);
+		metsAgent.setTYPE(MetsType.MetsHdr.Agent.TYPE.INDIVIDUAL);
+		metsAgent.setName("Markus Enders");
+		metsAgent.addNote("He is the the METS-api to create this file");
+
+		// Create first div; therefore we have to add a new struct map; while
+		// adding this structMap a StructMapType object is created.
+		//
+		// Create a new <StructMap> element.
+		StructMapType sm = myMets.addNewStructMap();
+
+		// Create first div.
+		DivType monograph_div = sm.addNewDiv();
+		// This div is a monograph.
+		monograph_div.setTYPE("Monograph");
+		// This ID must be XML compliant.
+		monograph_div.setID("MAINDIV01");
+		monograph_div.setLABEL("Monograph");
+
+		// Create metadata for the first div.
+		//
+		// Ceate the xml metadata first.
+		StringBuffer xmlmetadata = new StringBuffer();
+		// Set the namespace for the MODS part.
+		suggestedPrefixes.put("http://purl.org/DC#", "dc");
+		xmlmetadata
+				.append("<dc:identifier xmlns:dc=\"http://purl.org/DC#\"></dc:identifier>");
+		xmlmetadata.append("<dc:title></dc:title>");
+
+		// create binary metadata (e.g. orig. MARC record)
+		StringBuffer binmetadata = new StringBuffer();
+		binmetadata.append("Binary Data");
+
+		// Creating metadata is difficult, since it can be therefore we use the
+		// helper class from level 2 api.
+		Helper h = new Helper(myMets);
+
+		h.addDmdSecType(monograph_div, xmlmetadata.toString());
+		h.addDmdSecType(monograph_div, binmetadata.toString().getBytes());
+
+		// Save METS as file, but create options.
+		opts.setSaveSuggestedPrefixes(suggestedPrefixes);
+
+		// Save file using the given options.
+		File outputFile = new File("C:/myMets.xml");
+
+		try {
+			metsDocument.save(outputFile, opts);
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+
+	/**************************************************************************
+	 *
+	 **************************************************************************/
+	public void createMetsHeader() {
+		//
+	}
+
+}

--- a/ugh/src/ugh/dl/ContentFile.java
+++ b/ugh/src/ugh/dl/ContentFile.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 /*******************************************************************************
  * <p>
- * A ContentFile represents a file which must be accessable via the file system
+ * A ContentFile represents a file which must be accessible via the file system
  * and contains the content of the <code>DigitalDocument</code>. A ContentFile
  * belongs always to <code>FileSet</code>, which provides methods to add and
  * remove content files (<code>addFile</code> and <code>removeFile</code>.

--- a/ugh/src/ugh/dl/ContentFileArea.java
+++ b/ugh/src/ugh/dl/ContentFileArea.java
@@ -43,7 +43,7 @@ import ugh.exceptions.ContentFileAreaTypeUnknownException;
  * <li>
  * </ul>
  * byte-offset: If an area just contains the lowest entity, which can be
- * adressed in the content file (e.g. a single pixel, a single second, a single
+ * addressed in the content file (e.g. a single pixel, a single second, a single
  * xml-element), the from and to fields must contain the same values.
  * </p>
  * 

--- a/ugh/src/ugh/dl/DigitalDocument.java
+++ b/ugh/src/ugh/dl/DigitalDocument.java
@@ -106,7 +106,7 @@ import com.thoughtworks.xstream.mapper.MapperWrapper;
  * 
  *      TODO Remove all XStream things from here and put it into the XStream class!!
  * 
- *      TODO Maybe provide a possibility to change content file pathes in addContentFileFromPhysicalPage()!!
+ *      TODO Maybe provide a possibility to change content file paths in addContentFileFromPhysicalPage()!!
  * 
  *      CHANGELOG
  *      
@@ -559,7 +559,7 @@ public class DigitalDocument implements Serializable {
 
     /***************************************************************************
      * <p>
-     * Sorts all metadata and persons recursively in this DocStruct according to their occurance in the preferences file.
+     * Sorts all metadata and persons recursively in this DocStruct according to their occurrence in the preferences file.
      * </p>
      **************************************************************************/
     public synchronized void sortMetadataRecursively(Prefs thePrefs) {
@@ -689,7 +689,7 @@ public class DigitalDocument implements Serializable {
 
     /***************************************************************************
      * <p>
-     * Sorts all metadata and persons recursively for the given DocStruct according to their occurance in the preferences file.
+     * Sorts all metadata and persons recursively for the given DocStruct according to their occurrence in the preferences file.
      * </p>
      **************************************************************************/
     private synchronized void sortMetadataRecursively(DocStruct theSruct, Prefs thePrefs) {

--- a/ugh/src/ugh/dl/DocStruct.java
+++ b/ugh/src/ugh/dl/DocStruct.java
@@ -149,11 +149,11 @@ import ugh.fileformats.mets.MetsModsImportExport;
  * 
  *      29.09.2009 --- Funk --- Added the sortMetadataAbcdefg() methods.
  * 
- *      17.09.2009 --- Funk --- Fixed some NullPointerException occurances in sortMetadata().
+ *      17.09.2009 --- Funk --- Fixed some NullPointerException occurrences in sortMetadata().
  * 
  *      11.09.2009 --- Wulf Riebensahm --- Equals method overloaded.
  * 
- *      08.06.2009 --- Funk --- Added the method sortMetadataRecursively, to be able to sort the metadata according to the prefs occurance.
+ *      08.06.2009 --- Funk --- Added the method sortMetadataRecursively, to be able to sort the metadata according to the prefs occurrence.
  * 
  *      03.06.2009 --- Funk --- Added null check in countMDofthisType
  * 
@@ -542,7 +542,7 @@ public class DocStruct implements Serializable {
         } catch (TypeNotAllowedForParentException e) {
             // This should never happen as we are creating the same
             // DocStructType.
-            String message = "This " + e.getClass().getName() + " should not have been occured!";
+            String message = "This " + e.getClass().getName() + " should not have been occurred!";
             LOGGER.error(message, e);
         }
 
@@ -570,12 +570,12 @@ public class DocStruct implements Serializable {
                     } catch (DocStructHasNoTypeException e) {
                         // This should never happen, as we are adding the same
                         // MetadataType.
-                        String message = "This " + e.getClass().getName() + " should not have been occured!";
+                        String message = "This " + e.getClass().getName() + " should not have been occurred!";
                         LOGGER.error(message, e);
                     } catch (MetadataTypeNotAllowedException e) {
                         // This should never happen, as we are adding the same
                         // MetadataType.
-                        String message = "This " + e.getClass().getName() + " should not have been occured!";
+                        String message = "This " + e.getClass().getName() + " should not have been occurred!";
                         LOGGER.error(message, e);
                     }
                 }
@@ -631,12 +631,12 @@ public class DocStruct implements Serializable {
                     } catch (DocStructHasNoTypeException e) {
                         // This should never happen, as we are adding the same
                         // MetadataType.
-                        String message = "This " + e.getClass().getName() + " should not have been occured!";
+                        String message = "This " + e.getClass().getName() + " should not have been occurred!";
                         LOGGER.error(message, e);
                     } catch (MetadataTypeNotAllowedException e) {
                         // This should never happen, as we are adding the same
                         // MetadataType.
-                        String message = "This " + e.getClass().getName() + " should not have been occured!";
+                        String message = "This " + e.getClass().getName() + " should not have been occurred!";
                         LOGGER.error(message, e);
                     }
 
@@ -672,12 +672,12 @@ public class DocStruct implements Serializable {
                     } catch (IncompletePersonObjectException e) {
                         // This should never happen as we are adding the same
                         // person type.
-                        String message = "This " + e.getClass().getName() + " should not have been occured!";
+                        String message = "This " + e.getClass().getName() + " should not have been occurred!";
                         LOGGER.error(message, e);
                     } catch (MetadataTypeNotAllowedException e) {
                         // This should never happen as we are adding the same
                         // person type.
-                        String message = "This " + e.getClass().getName() + " should not have been occured!";
+                        String message = "This " + e.getClass().getName() + " should not have been occurred!";
                         LOGGER.error(message, e);
                     }
                 }
@@ -696,7 +696,7 @@ public class DocStruct implements Serializable {
 				try {
 					newStruct.addChild(copiedChild);
 				} catch (TypeNotAllowedAsChildException e) {
-					String message = "This " + e.getClass().getName() + " should not have been occured!";
+					String message = "This " + e.getClass().getName() + " should not have been occurred!";
 					LOGGER.error(message, e);
 				}
 			}
@@ -1221,7 +1221,7 @@ public class DocStruct implements Serializable {
             fs = this.digdoc.getFileSet();
         }
 
-        // Add the file, existance check is done in FileSet.addFile() now.
+        // Add the file, existence check is done in FileSet.addFile() now.
         fs.addFile(theFile);
 
         if (this.contentFileReferences == null) {
@@ -1451,7 +1451,7 @@ public class DocStruct implements Serializable {
      * </p>
      * 
      * @param theMetadataGroup Metadata object to be added.
-     * @return TRUE if metadata was added succesfully, FALSE otherwise.
+     * @return TRUE if metadata was added successfully, FALSE otherwise.
      * @throws MetadataTypeNotAllowedException If the DocStructType of this DocStruct instance does not allow the MetadataType or if the maximum
      *             number of Metadata (of this type) is already available.
      * @throws DocStructHasNoTypeException If no DocStruct Type is set for the DocStruct object; for this reason the metadata can't be added, because
@@ -1474,7 +1474,7 @@ public class DocStruct implements Serializable {
         // First get MetadataType object for the DocStructType to which this
         // document structure belongs to get global MDType.
         if (this.type == null) {
-            String message = "Error occured while adding metadata group of type '" + inMdName + "' to " + identify(this) + " DocStruct: DocStruct has no type.";
+            String message = "Error occurred while adding metadata group of type '" + inMdName + "' to " + identify(this) + " DocStruct: DocStruct has no type.";
             LOGGER.error(message);
             throw new DocStructHasNoTypeException(message);
         }
@@ -1712,7 +1712,7 @@ public class DocStruct implements Serializable {
      * </p>
      * 
      * @param theMetadata Metadata object to be added.
-     * @return TRUE if metadata was added succesfully, FALSE otherwise.
+     * @return TRUE if metadata was added successfully, FALSE otherwise.
      * @throws MetadataTypeNotAllowedException If the DocStructType of this DocStruct instance does not allow the MetadataType or if the maximum
      *             number of Metadata (of this type) is already available.
      * @throws DocStructHasNoTypeException If no DocStruct Type is set for the DocStruct object; for this reason the metadata can't be added, because
@@ -1735,7 +1735,7 @@ public class DocStruct implements Serializable {
         // First get MetadataType object for the DocStructType to which this
         // document structure belongs to get global MDType.
         if (this.type == null) {
-            String message = "Error occured while adding metadata of type '" + inMdName + "' to " + identify(this) + " DocStruct: DocStruct has no type.";
+            String message = "Error occurred while adding metadata of type '" + inMdName + "' to " + identify(this) + " DocStruct: DocStruct has no type.";
             LOGGER.error(message);
             throw new DocStructHasNoTypeException(message);
         }
@@ -3308,7 +3308,7 @@ public class DocStruct implements Serializable {
 
     /***************************************************************************
      * <p>
-     * Sorts the metadata and persons in the current DocStruct according to their occurance in the preferences file.
+     * Sorts the metadata and persons in the current DocStruct according to their occurrence in the preferences file.
      * </p>
      * 
      * @param thePrefs
@@ -3533,7 +3533,7 @@ public class DocStruct implements Serializable {
         // Only if also the number of Objects in the lists is the same we need
         // an exhausting in depth comparism of the Objects contained.
         // Simply using the List.equals method doesn't help us, because the
-        // lists may only have two seperate instances of equal objects but
+        // lists may only have two separate instances of equal objects but
         // never the same instances.
         ListPairCheck lpcResult = null;
 

--- a/ugh/src/ugh/dl/Fileformat.java
+++ b/ugh/src/ugh/dl/Fileformat.java
@@ -102,7 +102,7 @@ public interface Fileformat {
 	 * 
 	 * @param filename
 	 *            full path to the file
-	 * @return true, if everything is okay. Otherwise false, if an error occured
+	 * @return true, if everything is okay. Otherwise false, if an error occurred
 	 *         (IO-Error etc...)
 	 * @throws WriteException
 	 * @throws PreferencesException
@@ -132,7 +132,7 @@ public interface Fileformat {
 	 * </p>
 	 * 
 	 * @param inDoc
-	 * @return true; only if a problem occured, false is returned.
+	 * @return true; only if a problem occurred, false is returned.
 	 **************************************************************************/
 	public boolean setDigitalDocument(DigitalDocument inDoc);
 

--- a/ugh/src/ugh/dl/Metadata.java
+++ b/ugh/src/ugh/dl/Metadata.java
@@ -120,7 +120,7 @@ public class Metadata implements Serializable {
 
     /***************************************************************************
      * <p>
-     * Returns the DocStruct instance, to which this metadata object belongs. This is extremly helpful, if only the metadata instance is stored in a
+     * Returns the DocStruct instance, to which this metadata object belongs. This is extremely helpful, if only the metadata instance is stored in a
      * list; the reference to the associated DocStrct instance is always kept.
      * </p>
      * 

--- a/ugh/src/ugh/dl/MetadataGroup.java
+++ b/ugh/src/ugh/dl/MetadataGroup.java
@@ -108,7 +108,7 @@ public class MetadataGroup implements Serializable {
 
     /***************************************************************************
      * <p>
-     * Returns the DocStruct instance, to which this metadataGroup object belongs. This is extremly helpful, if only the metadata instance is stored
+     * Returns the DocStruct instance, to which this metadataGroup object belongs. This is extremely helpful, if only the metadata instance is stored
      * in a list; the reference to the associated DocStrct instance is always kept.
      * </p>
      * 

--- a/ugh/src/ugh/dl/MetadataGroupType.java
+++ b/ugh/src/ugh/dl/MetadataGroupType.java
@@ -43,7 +43,7 @@ public class MetadataGroupType implements Serializable {
     // Unique name of MetadataType.
     private String name;
 
-    // Maximum number of occurences of this MetadataType for one DocStrct (can
+    // Maximum number of occurrences of this MetadataType for one DocStrct (can
     // be 1 (1), one or more (+) or as many as you want (*).
     private String max_number;
 

--- a/ugh/src/ugh/dl/MetadataType.java
+++ b/ugh/src/ugh/dl/MetadataType.java
@@ -37,12 +37,12 @@ import java.util.Map;
  * 
  * <p>
  * Besides the internal name, a MetadataType object contains information, about
- * it occurences; some metadata may occur just once, other may occur many times.
+ * it occurrences; some metadata may occur just once, other may occur many times.
  * </p>
  * <p>
- * E.g. for all titles of a document there can be a seperate MetadataType
+ * E.g. for all titles of a document there can be a separate MetadataType
  * element, which contains information about this class of metadata elements.
- * Information which they share are information about their occurences; each
+ * Information which they share are information about their occurrences; each
  * structure entity can only have a single title.<BR>
  * MetadataType objects can occur in two different ways:
  * </p>
@@ -60,7 +60,7 @@ import java.util.Map;
  * which a MetadataType object is used. When adding a <code>MetadataType</code>
  * object to a <DocStructType> object, an internal copy is created and stored
  * with the <code>DocStructType</code> object. This copy is called locally and
- * may store information about its occurences in this special
+ * may store information about its occurrences in this special
  * <code>DocStructType</code> object. The <code>DocStructType</code> class
  * contains methods to retrieve local <code>MetadataType</code> objects from
  * global ones.
@@ -95,7 +95,7 @@ public class MetadataType implements Serializable {
 	// Unique name of MetadataType.
 	private String					name;
 
-	// Maximum number of occurences of this MetadataType for one DocStrct (can
+	// Maximum number of occurrences of this MetadataType for one DocStrct (can
 	// be 1 (1), one or more (+) or as many as you want (*).
 	private String					max_number;
 
@@ -148,7 +148,7 @@ public class MetadataType implements Serializable {
 	 * </p>
 	 * <p>
 	 * The copy contains the same languages, the same internal name and the
-	 * number of possible occurences as the original.
+	 * number of possible occurrences as the original.
 	 * </p>
 	 * 
 	 * @return the newly created MetadataType

--- a/ugh/src/ugh/dl/Prefs.java
+++ b/ugh/src/ugh/dl/Prefs.java
@@ -439,7 +439,7 @@ public class Prefs implements Serializable {
                     }
 
                     if (result == null) {
-                        // Error occured; so exit this method; no new
+                        // Error occurred; so exit this method; no new
                         // DocStrctType.
                         LOGGER.error("Error reading config for DocStrctType '" + currentDocStrctType.getName() + "'! Can't add metadatatype '"
                                 + newMdType.getName() + "'");
@@ -519,7 +519,7 @@ public class Prefs implements Serializable {
                     }
 
                     if (result == null) {
-                        // Error occured; so exit this method; no new
+                        // Error occurred; so exit this method; no new
                         // DocStrctType.
                         LOGGER.error("Error reading config for DocStrctType '" + currentDocStrctType.getName() + "'! Can't add metadatatype '"
                                 + newMdGroup.getName() + "'");
@@ -547,7 +547,7 @@ public class Prefs implements Serializable {
                     // Check, if an appropriate DocStruct Type is defined.
                     boolean bResult = currentDocStrctType.addDocStructTypeAsChild(allowedChild);
                     if (!bResult) {
-                        // Error occured; so exit this method; no new
+                        // Error occurred; so exit this method; no new
                         // DocStrctType.
                         LOGGER.error("Error reading config for DocStructType '" + currentDocStrctType.getName()
                                 + "'! Can't addDocStructType as child '" + allowedChild + "'");

--- a/ugh/src/ugh/dl/VirtualFileGroup.java
+++ b/ugh/src/ugh/dl/VirtualFileGroup.java
@@ -41,7 +41,7 @@ import java.io.Serializable;
  * 
  *      30.10.2009 --- Funk --- Added generated serialVersionUID.
  * 
- *      16.01.2009 --- Funk --- Made the suffix input "." resistent!
+ *      16.01.2009 --- Funk --- Made the suffix input "." resistant!
  * 
  ******************************************************************************/
 

--- a/ugh/src/ugh/exceptions/MissingModsMappingException.java
+++ b/ugh/src/ugh/exceptions/MissingModsMappingException.java
@@ -104,7 +104,7 @@ public class MissingModsMappingException extends UGHException {
 					+ listEntries.toString().trim();
 		}
 
-		return "Error occured for unknown reason";
+		return "Error occurred for unknown reason";
 	}
 
 	/***************************************************************************

--- a/ugh/src/ugh/fileformats/excel/Excelfile.java
+++ b/ugh/src/ugh/fileformats/excel/Excelfile.java
@@ -980,7 +980,7 @@ public class Excelfile implements ugh.dl.Fileformat {
 	 *            single sheet of a whole excel file containing the pagination
 	 *            sequences
 	 * @param pathasstring
-	 * @return true, if everthing is okay; otherwise false
+	 * @return true, if everything is okay; otherwise false
 	 * @throws MetadataTypeNotAllowedException
 	 **************************************************************************/
 	private boolean ReadPaginationSequences(HSSFSheet inSheet,
@@ -1526,7 +1526,7 @@ public class Excelfile implements ugh.dl.Fileformat {
 				} else {
 					if (levelcell.getCellType() != HSSFCell.CELL_TYPE_BLANK) {
 						System.err
-								.println("ERROR: Value of hierachy is NOT numeric (1) - line "
+								.println("ERROR: Value of hierarchy is NOT numeric (1) - line "
 										+ x);
 					}
 					continue;
@@ -2038,7 +2038,7 @@ public class Excelfile implements ugh.dl.Fileformat {
 					List<? extends Metadata> allmds = page
 							.getAllMetadataByType(physpagetype);
 					if ((allmds == null) || (allmds.size() > 1)) {
-						// Error occured; every page MUST HAVE a physical page
+						// Error occurred; every page MUST HAVE a physical page
 						// number.
 						System.out
 								.println("ERROR: Calculate EndPage: page does not have a physical pagenumber or more than one physical pagenumber");
@@ -2083,7 +2083,7 @@ public class Excelfile implements ugh.dl.Fileformat {
 		for (int i = 0; i < allchildren.size(); i++) {
 			DocStruct currentdoc = allchildren.get(i);
 			if (!CalculateEndPage(currentdoc)) {
-				// Error occured.
+				// Error occurred.
 				return false;
 			}
 		}
@@ -2359,7 +2359,7 @@ public class Excelfile implements ugh.dl.Fileformat {
 				// Read information about a single docstruct matching.
 				if (!readDocStructPrefs(currentNode)) {
 					System.err
-							.println("ERROR: Excelfile.readPrefs: error occured while reading docstructs for excel");
+							.println("ERROR: Excelfile.readPrefs: error occurred while reading docstructs for excel");
 					PreferencesException pe = new PreferencesException(
 							"ERROR - can't read preferences for Excel module (DocStruct section)");
 					throw pe;

--- a/ugh/src/ugh/fileformats/excel/RDFFile.java
+++ b/ugh/src/ugh/fileformats/excel/RDFFile.java
@@ -314,7 +314,7 @@ public class RDFFile implements ugh.dl.Fileformat {
 			if (currentNode.getNodeName().equals("AGORA:ImageSet")) {
 				try {
 					if (!parseImageSet(currentNode)) {
-						// Error occured while reading imageset.
+						// Error occurred while reading imageset.
 						String message = "Wrong file type! No <AGORA:ImageSet> element found!";
 						ugh.exceptions.ReadException re = new ugh.exceptions.ReadException(
 								message);
@@ -489,16 +489,16 @@ public class RDFFile implements ugh.dl.Fileformat {
 
 			// Build all logical structures (fill the DOM tree).
 			if (!writeDocStruct(rdf, this.mydoc.getLogicalDocStruct())) {
-				// Error occured while writing the RDF/XML file.
-				LOGGER.error("Error occured while writing logical docstruct");
+				// Error occurred while writing the RDF/XML file.
+				LOGGER.error("Error occurred while writing logical docstruct");
 				xmlFile.close();
 				return false;
 			}
 
 			// Build all physical structures.
 			if (!writePhysical(rdf)) {
-				// Error occured while writing the RDF/XML file.
-				LOGGER.error("Error occured while writing physical docstruct");
+				// Error occurred while writing the RDF/XML file.
+				LOGGER.error("Error occurred while writing physical docstruct");
 				xmlFile.close();
 				return false;
 			}
@@ -2085,7 +2085,7 @@ public class RDFFile implements ugh.dl.Fileformat {
 					// TODO Make the whitespace handling configurable!!
 					//
 					// Parse metadata and delete some characters as tabstops and
-					// newlines etc. The occurence of several spaces are
+					// newlines etc. The occurrence of several spaces are
 					// replaced by a single space character.
 					// metadataValue = metadataValue
 					// .replaceAll("[\n\t\b\f\r]", "");
@@ -2895,7 +2895,7 @@ public class RDFFile implements ugh.dl.Fileformat {
 					&& currentNode.getNodeName().equals("DocStruct")
 					&& !readDocStructPrefs(currentNode)) {
 				// Read information about a single docstruct matching.
-				String message = "Error occured while reading DocStructs";
+				String message = "Error occurred while reading DocStructs";
 				LOGGER.error(message);
 				return false;
 			}

--- a/ugh/src/ugh/fileformats/mets/MetsMods.java
+++ b/ugh/src/ugh/fileformats/mets/MetsMods.java
@@ -169,13 +169,13 @@ import ugh.exceptions.WriteException;
  *        WARNINGs into DEBUG loglevel. --- Changed a "&" into a "&&", was actually a typo! --- Throw a WriteException in writeLogDmd(), if the child
  *        of anchor DocStruct has no MODS metadata! We have then no identifier!
  * 
- *        24.02.2010 --- Funk --- " "s are now also beeing ignored inside of "'"s in the prefs XPath configuration.
+ *        24.02.2010 --- Funk --- " "s are now also being ignored inside of "'"s in the prefs XPath configuration.
  * 
  *        15.02.2010 --- Funk --- Logging version information now.
  * 
  *        14.02.2010 --- Funk --- Commented the whitespace things.
  * 
- *        12.02.2010 --- Funk --- "/"s are now beeing ignored inside of "'"s in the prefs XPath configuration.
+ *        12.02.2010 --- Funk --- "/"s are now being ignored inside of "'"s in the prefs XPath configuration.
  * 
  *        26.01.2010 --- Funk --- Fixed a bug not writing all the SMLINKS into the METS file in writeSMLinks.
  * 
@@ -209,7 +209,7 @@ import ugh.exceptions.WriteException;
  *        prefixes, uris, and schema locations.
  * 
  *        20.10.2009 --- Funk --- smlink section is only read for non-anchor structs now, fixes bug DPD-352 --- Added modifiers to all class
- *        atributes.
+ *        attributes.
  * 
  *        19.10.2009 --- Funk --- Persons with last name OR first name == "" are now be written, too!
  * 
@@ -243,7 +243,7 @@ import ugh.exceptions.WriteException;
  *        16.07.2009 --- Funk --- Namespaces are handled correctly now. METS is serialised using the METS XMLBeans.
  * 
  *        08.07.2009 --- Funk --- Namespaces now are first defined with default values, then definitions from the prefs are considered and default
- *        values are beeing changed.
+ *        values are being changed.
  * 
  *        26.06.2009 --- Funk --- ADMSEC is written no more for internal METS.
  * 
@@ -329,7 +329,7 @@ import ugh.exceptions.WriteException;
  * 
  *        29.09.2008 --- Funk --- Logging added.
  * 
- *        26.09.2008 --- Funk --- Prefixes and default namespace can be configured in the regelsatz now --- File group data (pathes, etc.) can be
+ *        26.09.2008 --- Funk --- Prefixes and default namespace can be configured in the regelsatz now --- File group data (paths, etc.) can be
  *        configured via setters now.
  * 
  *        19.08.2008 --- Funk --- Merging of METSMODS and METSMODSGDZ
@@ -951,7 +951,7 @@ public class MetsMods implements ugh.dl.Fileformat {
      * </p>
      * 
      * @param inNode
-     * @return true, if preferences were read succesfully, false otherwise.
+     * @return true, if preferences were read successfully, false otherwise.
      **************************************************************************/
     public void readPrefs(Node inNode) throws PreferencesException {
 
@@ -3153,7 +3153,7 @@ public class MetsMods implements ugh.dl.Fileformat {
             }
         }
 
-        // Check file group pathes, suffixes, and mimetypes, except for
+        // Check file group paths, suffixes, and mimetypes, except for
         // filegroup LOCAL.
         if (!theFilegroup.getName().equals(METS_FILEGROUP_LOCAL_STRING)) {
             if (theFilegroup.getPathToFiles().equals("")) {
@@ -3406,7 +3406,7 @@ public class MetsMods implements ugh.dl.Fileformat {
         if (allChildren != null) {
             for (DocStruct child : allChildren) {
                 if (writePhysDivs(div, child) == null) {
-                    // Error occured while writing div for child.
+                    // Error occurred while writing div for child.
                     return null;
                 }
             }
@@ -3546,7 +3546,7 @@ public class MetsMods implements ugh.dl.Fileformat {
         if (allChildren != null) {
             for (DocStruct child : allChildren) {
 				if (writeLogDivs(div, child, anchorClass) == null) {
-                    // Error occured while writing div for child.
+                    // Error occurred while writing div for child.
                     return null;
                 }
             }
@@ -4028,7 +4028,7 @@ public class MetsMods implements ugh.dl.Fileformat {
     private String substractStrings(String in1, String in2) {
 
         if (in2.equals("")) {
-            // There is nothing to substract.
+            // There is nothing to subtract.
             return in1;
         }
 
@@ -4052,7 +4052,7 @@ public class MetsMods implements ugh.dl.Fileformat {
 
     /***************************************************************************
      * <p>
-     * Splits the Xpath into subpathes. The "'"s also are now beeing ignored.
+     * Splits the Xpath into subpathes. The "'"s also are now being ignored.
      * </p>
      * 
      * @param in
@@ -4618,7 +4618,7 @@ public class MetsMods implements ugh.dl.Fileformat {
         if (allChildren != null) {
             for (DocStruct child : allChildren) {
                 if (!writeSingleSMLink(parentNode, child)) {
-                    // Error occured while writing div for child.
+                    // Error occurred while writing div for child.
                     return false;
                 }
             }

--- a/ugh/src/ugh/fileformats/mets/MetsModsImportExport.java
+++ b/ugh/src/ugh/fileformats/mets/MetsModsImportExport.java
@@ -393,7 +393,7 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
                                 Node valueNode = domDoc.createTextNode(metadataValue);
                                 createdNode.appendChild(valueNode);
 
-                                // The node was sucessfully written, remove the
+                                // The node was successfully written, remove the
                                 // metadata object from the notMappedMetadata
                                 // list.
                                 notMappedMetadataAndPersons.remove(md);
@@ -425,7 +425,7 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
                                 if (mmo.getWriteXPath() != null) {
                                     writeSingleModsMetadata(mmo.getWriteXPath(), mmo, m, dommodsnode, domDoc);
 
-                                    // The node was sucessfully written! Remove the
+                                    // The node was successfully written! Remove the
                                     // metadata object from the checklist.
                                     notMappedMetadataAndPersons.remove(m);
                                 }
@@ -456,7 +456,7 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
                             if (!isEmpty) {
                                 writeSingleModsGroup(mmo, group, dommodsnode, domDoc);
 
-                                // The node was sucessfully written! Remove the
+                                // The node was successfully written! Remove the
                                 // metadata object from the checklist.
                                 notMappedMetadataAndPersons.remove(group);
 
@@ -490,7 +490,7 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
                                 if (mmo.getWriteXPath() != null) {
                                     writeSingleModsPerson(mmo.getWriteXPath(), mmo, p, dommodsnode, domDoc);
 
-                                    // The node was sucessfully written! Remove the
+                                    // The node was successfully written! Remove the
                                     // person object from the checklist.
                                     notMappedMetadataAndPersons.remove(p);
                                 }
@@ -590,7 +590,7 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
                         // Write other metadata into MODS the section.
                         writeSingleModsMetadata(xquery, mmo, currentMd, dommodsnode, domDoc);
 
-                        // The node was sucessfully written! Remove the
+                        // The node was successfully written! Remove the
                         // metadata object from the notMappedMetadata list.
                         notMappedMetadataAndPersons.remove(currentMd);
                     }
@@ -618,7 +618,7 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
                         if (!isEmpty) {
                             writeSingleModsGroup(mmo, group, dommodsnode, domDoc);
 
-                            // The node was sucessfully written! Remove the
+                            // The node was successfully written! Remove the
                             // metadata object from the checklist.
                             notMappedMetadataAndPersons.remove(group);
 
@@ -655,7 +655,7 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
                 if (xquery != null) {
                     writeSingleModsPerson(xquery, mmo, currentPer, dommodsnode, domDoc);
 
-                    // The node was sucessfully written, remove the
+                    // The node was successfully written, remove the
                     // person object from the notMappedPersons list.
                     notMappedMetadataAndPersons.remove(currentPer);
                 }
@@ -1201,7 +1201,7 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
         if (allChildren != null) {
             for (DocStruct child : allChildren) {
                 if (writePhysDivs(div, child) == null) {
-                    // Error occured while writing div for child.
+                    // Error occurred while writing div for child.
                     return null;
                 }
             }
@@ -1388,7 +1388,7 @@ public class MetsModsImportExport extends ugh.fileformats.mets.MetsMods {
 					continue;
 				}
 				if (writeLogDivs(div, child, anchorClass) == null) {
-                    // Error occured while writing div for child.
+                    // Error occurred while writing div for child.
                     return null;
                 }
             }

--- a/ugh/src/ugh/fileformats/mets/XStream.java
+++ b/ugh/src/ugh/fileformats/mets/XStream.java
@@ -112,7 +112,7 @@ public class XStream implements ugh.dl.Fileformat {
 		}
 
 		LOGGER
-				.info("Sorting metadata according to occurance in the Preferences");
+				.info("Sorting metadata according to occurrence in the Preferences");
 
 		this.digdoc.sortMetadataRecursively(this.myPreferences);
 

--- a/ugh/src/ugh/fileformats/opac/PicaPlus.java
+++ b/ugh/src/ugh/fileformats/opac/PicaPlus.java
@@ -574,7 +574,7 @@ public class PicaPlus implements ugh.dl.Fileformat {
 								// Parse a single picaplus record.
 								ds = parsePicaPlusRecord(n);
 								// It's the first one, so this becomes the
-								// toplogical structual entity.
+								// toplogical structural entity.
 								if (dsOld == null) {
 									this.mydoc.setLogicalDocStruct(ds);
 									dsTop = ds;
@@ -677,7 +677,7 @@ public class PicaPlus implements ugh.dl.Fileformat {
 									// Parse a single picaplus record.
 									ds = parsePicaPlusRecord(n);
 									// It's the first one, so this becomes the
-									// toplogical structual entity.
+									// toplogical structural entity.
 									if (dsOld == null) {
 										this.mydoc.setLogicalDocStruct(ds);
 										dsTop = ds;


### PR DESCRIPTION
The first patch only fixes end of line characters. The second patch fixes typos, mostly in comments,
but also in program messages.