### PR TITLE
Remove space characters before linefeeds in strings

### DIFF
--- a/ugh/src/converter/metsProcessing/ConversionStarter.java
+++ b/ugh/src/converter/metsProcessing/ConversionStarter.java
@@ -15,13 +15,13 @@ public class ConversionStarter {
 	 */
 	public static void main(String[] args) throws Exception {
 
-		String answer = getInput("Sie sind dabei die Umwandlung aller Ihrer digitalen Dokumente \n" +
-				"in das interne Mets Speicherformat zu starten. Wegen einer Änderung in UGH \n" +
-				"sollten Sie für die automatische Validierung vorher \n" +
-				" '<AGORA:PageNotAccountedStart>0</AGORA:PageNotAccountedStart>' gegen '<AGORA:PageNotAccountedStart>-1</AGORA:PageNotAccountedStart>' und \n" +
-				" '<AGORA:PageNotAccountedEnd>0</AGORA:PageNotAccountedEnd>' gegen '<AGORA:PageNotAccountedEnd>-1</AGORA:PageNotAccountedEnd>' \n" +
-				"in allen meta.xml Dateien ersetzen. \n" +
-				"Dazu genügt ein einfacher Text Editor wie z.B. PSPad (http://www.pspad.com/de/). \n" +
+		String answer = getInput("Sie sind dabei die Umwandlung aller Ihrer digitalen Dokumente\n" +
+				"in das interne Mets Speicherformat zu starten. Wegen einer Änderung in UGH\n" +
+				"sollten Sie für die automatische Validierung vorher\n" +
+				" '<AGORA:PageNotAccountedStart>0</AGORA:PageNotAccountedStart>' gegen '<AGORA:PageNotAccountedStart>-1</AGORA:PageNotAccountedStart>' und\n" +
+				" '<AGORA:PageNotAccountedEnd>0</AGORA:PageNotAccountedEnd>' gegen '<AGORA:PageNotAccountedEnd>-1</AGORA:PageNotAccountedEnd>'\n" +
+				"in allen meta.xml Dateien ersetzen.\n" +
+				"Dazu genügt ein einfacher Text Editor wie z.B. PSPad (http://www.pspad.com/de/).\n" +
 				"Wenn Sie die bereits erledigt haben und nun starten möchten tun Sie dieses mit der Eingabe von 'y'");
 		if (answer.toLowerCase().equals("y")) {
 			ProcessStarter.main(null);


### PR DESCRIPTION
There is no use in printing an invisible space character
at the end of a line.

Signed-off-by: Stefan Weil <sw@weilnetz.de>