### PR TITLE
RDFFile: Fix wrong comparision (reported by FindBugs)

### DIFF
--- a/ugh/src/ugh/fileformats/excel/RDFFile.java
+++ b/ugh/src/ugh/fileformats/excel/RDFFile.java
@@ -2683,7 +2683,7 @@ public class RDFFile implements ugh.dl.Fileformat {
 										// all.
 										else if (currentNode4 != null
 												&& currentNode4.getNodeValue() != null
-												&& !currentNode4.equals("")) {
+												&& !currentNode4.getNodeValue().equals("")) {
 											resultPerson
 													.setDisplayname(currentNode4
 															.getNodeValue());


### PR DESCRIPTION
It makes no sense to compare currentNode4 with an empty string.

Signed-off-by: Stefan Weil <sw@weilnetz.de>