### PR TITLE
Switch build environment from trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 # Travis continuous integration for Kitodo.UGH
 
-dist: trusty
+dist: xenial
 
 language: java
 
 jdk:
-  - oraclejdk8
   - openjdk8
 
 addons:


### PR DESCRIPTION
Updating Travis build infrastructure from trusty to xenial.

Disadvantage of Xenial is removed support for OracleJDK8.