### PR TITLE
2.x: Switch build environment from trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 # Travis continuous integration for Kitodo.UGH
 
-dist: trusty
+dist: xenial
 
 language: java
 
 jdk:
-  - oraclejdk8
   - openjdk8
 
 addons:
@@ -13,5 +12,8 @@ addons:
 cache:
 
 env:
+
+before_install:
+  - sudo apt-get install -y ant
 
 script: cd ugh && ant all


### PR DESCRIPTION
Updating Travis build infrastructure from trusty to xenial.

Disadvantage: removed OracleJDK8 support in Xenial.